### PR TITLE
Avoid crash in imageSegmentationFromPrompt node when no detection occurs

### DIFF
--- a/segmentationRDS/segmentation.py
+++ b/segmentationRDS/segmentation.py
@@ -159,6 +159,7 @@ class SegmentationRDS:
 
         recoOK, tags = self.recognize(wordlist, image, verbose)
         bboxes = []
+        confidence = []
         mask_image = np.zeros_like(image)
         if recoOK or force:
             bboxes, confidence = self.detect(image=image, TEXT_PROMPT=prompt, BOX_THRESHOLD=threshold)


### PR DESCRIPTION
This PR fixes a bug in the  imageSegmentationFromPrompt node that pop up at the detection stage when the queried element is not recognized in the input image. In this case the detection is not launched and no list of confidences is produced leading to the crash when this list must be returned.

The bug is solved by Initializing the confidence list with an empty list.