### PR TITLE
[meshroom] Replace `os.getenv("var")` with `"${var}"` in nodes

### DIFF
--- a/meshroom/imageSegmentation/ImageDetectionPrompt.py
+++ b/meshroom/imageSegmentation/ImageDetectionPrompt.py
@@ -32,19 +32,19 @@ Bounded box sizes can be increased by a ratio from 0 to 100%.
             name="recognitionModelPath",
             label="Recognition Model",
             description="Weights file for the recognition model.",
-            value=os.getenv("RDS_RECOGNITION_MODEL_PATH", ""),
+            value="${RDS_RECOGNITION_MODEL_PATH}",
         ),
         desc.File(
             name="detectionModelPath",
             label="Detection Model",
             description="Weights file for the detection model.",
-            value=os.getenv("RDS_DETECTION_MODEL_PATH", ""),
+            value="${RDS_DETECTION_MODEL_PATH}",
         ),
         desc.File(
             name="detectionConfigPath",
             label="Detection Config",
             description="Config file for the detection model.",
-            value=os.getenv("RDS_DETECTION_CONFIG_PATH", ""),
+            value="${RDS_DETECTION_CONFIG_PATH}",
         ),
         desc.StringParam(
             name="prompt",
@@ -182,9 +182,9 @@ Bounded box sizes can be increased by a ratio from 0 to 100%.
 
             os.environ["TOKENIZERS_PARALLELISM"] = "true"  # required to avoid warning on tokenizers
 
-            processor = segmentation.DetectAnything(RAM_CHECKPOINT_PATH = chunk.node.recognitionModelPath.value,
-                                                    GD_CONFIG_PATH = chunk.node.detectionConfigPath.value,
-                                                    GD_CHECKPOINT_PATH = chunk.node.detectionModelPath.value,
+            processor = segmentation.DetectAnything(RAM_CHECKPOINT_PATH = chunk.node.recognitionModelPath.evalValue,
+                                                    GD_CONFIG_PATH = chunk.node.detectionConfigPath.evalValue,
+                                                    GD_CHECKPOINT_PATH = chunk.node.detectionModelPath.evalValue,
                                                     useGPU = chunk.node.useGpu.value)
 
             prompt = chunk.node.prompt.value.replace("\n", ".")

--- a/meshroom/imageSegmentation/ImageSegmentationBox.py
+++ b/meshroom/imageSegmentation/ImageSegmentationBox.py
@@ -51,7 +51,7 @@ In case neither tracker nor json file is available, the model is applied on the 
             name="segmentationModelPath",
             label="Segmentation Model",
             description="Weights file for the segmentation model.",
-            value=os.getenv("RDS_SEGMENTATION_MODEL_PATH", ""),
+            value="${RDS_SEGMENTATION_MODEL_PATH}",
         ),
         desc.BoolParam(
             name="maskInvert",
@@ -174,7 +174,7 @@ In case neither tracker nor json file is available, the model is applied on the 
             if not os.path.exists(chunk.node.output.value):
                 os.mkdir(chunk.node.output.value)
 
-            processor = segmentation.SegmentAnything(SAM_CHECKPOINT_PATH = chunk.node.segmentationModelPath.value,
+            processor = segmentation.SegmentAnything(SAM_CHECKPOINT_PATH = chunk.node.segmentationModelPath.evalValue,
                                                      useGPU = chunk.node.useGpu.value)
 
             bboxDict = {}

--- a/meshroom/imageSegmentation/ImageSegmentationPrompt.py
+++ b/meshroom/imageSegmentation/ImageSegmentationPrompt.py
@@ -32,25 +32,25 @@ Bounded box sizes can be increased by a ratio from 0 to 100%.
             name="recognitionModelPath",
             label="Recognition Model",
             description="Weights file for the recognition model.",
-            value=os.getenv("RDS_RECOGNITION_MODEL_PATH", ""),
+            value="${RDS_RECOGNITION_MODEL_PATH}",
         ),
         desc.File(
             name="detectionModelPath",
             label="Detection Model",
             description="Weights file for the detection model.",
-            value=os.getenv("RDS_DETECTION_MODEL_PATH", ""),
+            value="${RDS_DETECTION_MODEL_PATH}",
         ),
         desc.File(
             name="detectionConfigPath",
             label="Detection Config",
             description="Config file for the detection model.",
-            value=os.getenv("RDS_DETECTION_CONFIG_PATH", ""),
+            value="${RDS_DETECTION_CONFIG_PATH}",
         ),
         desc.File(
             name="segmentationModelPath",
             label="Segmentation Model",
             description="Weights file for the segmentation model.",
-            value=os.getenv("RDS_SEGMENTATION_MODEL_PATH", ""),
+            value="${RDS_SEGMENTATION_MODEL_PATH}",
         ),
         desc.StringParam(
             name="prompt",
@@ -200,10 +200,10 @@ Bounded box sizes can be increased by a ratio from 0 to 100%.
 
             os.environ["TOKENIZERS_PARALLELISM"] = "true"  # required to avoid warning on tokenizers
 
-            processor = segmentation.SegmentationRDS(RAM_CHECKPOINT_PATH = chunk.node.recognitionModelPath.value,
-                                                     GD_CONFIG_PATH = chunk.node.detectionConfigPath.value,
-                                                     GD_CHECKPOINT_PATH = chunk.node.detectionModelPath.value,
-                                                     SAM_CHECKPOINT_PATH = chunk.node.segmentationModelPath.value,
+            processor = segmentation.SegmentationRDS(RAM_CHECKPOINT_PATH = chunk.node.recognitionModelPath.evalValue,
+                                                     GD_CONFIG_PATH = chunk.node.detectionConfigPath.evalValue,
+                                                     GD_CHECKPOINT_PATH = chunk.node.detectionModelPath.evalValue,
+                                                     SAM_CHECKPOINT_PATH = chunk.node.segmentationModelPath.evalValue,
                                                      useGPU = chunk.node.useGpu.value)
 
             prompt = chunk.node.prompt.value.replace("\n", ".")

--- a/meshroom/imageSegmentation/ImageTagsExtraction.py
+++ b/meshroom/imageSegmentation/ImageTagsExtraction.py
@@ -26,7 +26,7 @@ Generate a set of tags corresponding to recognized elements using a recognition 
             name="recognitionModelPath",
             label="Recognition Model",
             description="Weights file for the recognition model.",
-            value=os.getenv("RDS_RECOGNITION_MODEL_PATH", ""),
+            value="${RDS_RECOGNITION_MODEL_PATH}",
         ),
         desc.BoolParam(
             name="useGpu",
@@ -129,7 +129,7 @@ Generate a set of tags corresponding to recognized elements using a recognition 
 
             os.environ["TOKENIZERS_PARALLELISM"] = "true"  # required to avoid warning on tokenizers
 
-            processor = segmentation.RecognizeAnything(RAM_CHECKPOINT_PATH = chunk.node.recognitionModelPath.value,
+            processor = segmentation.RecognizeAnything(RAM_CHECKPOINT_PATH = chunk.node.recognitionModelPath.evalValue,
                                                        useGPU = chunk.node.useGpu.value)
 
             dict = {}


### PR DESCRIPTION
This PR removes all the `os.getenv("var")` from the default values for attributes, and replaces them with `"${var}"` instead. Every single time one of these attributes' value is needed, it is provided with the `evalValue` property rather than the `value` one, which does not resolve the variable.
