### PR TITLE
[requirements] Provide branch for BiRefNet

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 ram @ git+https://github.com/xinyu1205/recognize-anything.git
 groundingdino-py==0.4.0
 segment-anything==1.0
-birefnet @ git+https://github.com/meshroomHubWarehouse/BiRefNet.git
+birefnet @ git+https://github.com/meshroomHubWarehouse/BiRefNet.git@compatibilityPython3.9


### PR DESCRIPTION
Update the requirements.txt file so that the branch for BiRefNet is correctly set. On the "compatibilityPython3.9" branch, a setup.py is added to make the repo installable through pip.