### PR TITLE
Use AV Python binding for image read and write

### DIFF
--- a/segmentationRDS/image.py
+++ b/segmentationRDS/image.py
@@ -1,57 +1,7 @@
 import os
 import numpy as np
 import OpenImageIO as oiio
-
-knowncolorspaces = ['srgb', 'linear_srgb', 'aces', 'acescg']
-
-IDENTITY_mat = np.array([[1.0, 0.0, 0.0],[0.0, 1.0, 0.0],[0.0, 0.0, 1.0]])
-
-ACES_AP1_TO_AP0_mat = np.array([[0.6954522414, 0.1406786965, 0.1638690622],
-                                [0.0447945634, 0.8596711185, 0.0955343182],
-                                [-0.0055258826, 0.0040252103, 1.0015006723]])
-
-ACES_AP0_TO_sRGB_mat = np.array([[2.52140088857822, -1.13399574938275, -0.387561856768867],
-                                 [-0.276214061561748, 1.37259556630409, -0.0962823557364663],
-                                 [-0.0153202000774786, -0.152992561800699, 1.16838719961932]])
-
-ACES_AP1_TO_sRGB_mat = ACES_AP0_TO_sRGB_mat @ ACES_AP1_TO_AP0_mat
-
-def get_conversion_matrix(fromcolorspace:str, tocolorspace:str) -> np.ndarray:
-    if not fromcolorspace in knowncolorspaces:
-        print("Warning: {} color space is unknown, identity matrix returned !!!".format(fromcolorspace))
-        return IDENTITY_mat
-    if not tocolorspace in knowncolorspaces:
-        print("Warning: {} color space is unknown, identity matrix returned !!!".format(tocolorspace))
-        return IDENTITY_mat
-    if fromcolorspace == tocolorspace:
-        return IDENTITY_mat
-    if fromcolorspace == 'srgb' or fromcolorspace == 'linear_srgb':
-        if tocolorspace == 'aces':
-            return ACES_AP0_TO_sRGB_mat.I
-        elif tocolorspace == 'acescg':
-            return ACES_AP1_TO_sRGB_mat.I
-        else:
-            return IDENTITY_mat
-    elif fromcolorspace == 'aces':
-        if tocolorspace == 'srgb' or tocolorspace == 'linear_srgb':
-            return ACES_AP0_TO_sRGB_mat
-        elif tocolorspace == 'acescg':
-            return ACES_AP1_TO_AP0_mat.I
-        else:
-            return IDENTITY_mat
-    elif fromcolorspace == 'acescg':
-        if tocolorspace == 'srgb' or tocolorspace == 'linear_srgb':
-            return ACES_AP1_TO_sRGB_mat
-        elif tocolorspace == 'aces':
-            return ACES_AP1_TO_AP0_mat
-        else:
-            return IDENTITY_mat
-
-def srgb_gamma_inv(x):
-    if x < 0.003039935:
-        return 12.92321018 * max(0.0, x)
-    else:
-        return 1.055 * pow(min(1.0, x), 1.0/2.4) - 0.055
+from pyalicevision import image as avimg
 
 def find_metadata(oiio_spec, name: str, default, exact: bool = True):
     values = []
@@ -103,15 +53,21 @@ def apply_orientation(oiio_image, orientation, reverse: bool = False):
     return oiio_image
 
 
-def loadImage(imagePath: str, applyPAR: bool = False, applyOrientation: bool = True, incolorspace: str = 'acescg'):
+def loadImage(imagePath: str, applyPAR: bool = False, applyOrientation: bool = True):
     oiio_input = oiio.ImageInput.open(imagePath)
-    oiio_spec = oiio_input.spec ()
-    oiio_image = oiio_input.read_image(0, 3)
+    oiio_spec = oiio_input.spec()
+    oiio_input.close()
+
+    av_image = avimg.Image_RGBfColor()
+    avOptRead = avimg.ImageReadOptions(avimg.EImageColorSpace_SRGB)
+    avimg.readImage(imagePath, av_image, avOptRead)
+    oiio_image = av_image.getNumpyArray()
+
     pixelAspectRatio = oiio_spec.get_float_attribute('PixelAspectRatio', 1.0)
     orientation = int(find_metadata(oiio_spec, 'Orientation', 1)[0])
     oiio_spec.attribute('Orientation', orientation)
 
-    if orientation > 1:
+    if orientation > 1 and applyOrientation:
         oiio_image = apply_orientation(oiio_image, orientation)
 
     h,w,c = oiio_image.shape
@@ -122,18 +78,10 @@ def loadImage(imagePath: str, applyPAR: bool = False, applyOrientation: bool = T
         oiio_image_buf = oiio.ImageBufAlgo.resize(oiio_image_buf, roi=oiio.ROI(0, w, 0, nh, 0, 1, 0, c+1))
         oiio_image = oiio_image_buf.get_pixels(format=oiio.FLOAT)
 
-    if imagePath[-4:].lower() == ".exr":
-        convmat = get_conversion_matrix(incolorspace, 'srgb')
-        convmat_oiio = tuple(map(tuple, convmat.T))
-        convmat_oiio = convmat_oiio[0] + (0.0,) + convmat_oiio[1] + (0.0,) + convmat_oiio[2] + (0.,0.,0.,0.,1.)
-        oiio_image_buf = oiio.ImageBuf(oiio_image)
-        oiio_image_buf = oiio.ImageBufAlgo.colormatrixtransform(oiio_image_buf, convmat_oiio)
-        oiio_image = oiio_image_buf.get_pixels(format=oiio.FLOAT)
-        np_srgb_gamma_inv = np.frompyfunc(srgb_gamma_inv, 1, 1)
-        ginv = np_srgb_gamma_inv(np.array(range(100000)) / 100000)
-        oiio_image = ginv[np.clip(100000 * oiio_image, 0, 99999).astype('int')].astype('float32')
-
-    oiio_input.close()
+    oiio_image_buf = oiio.ImageBuf(oiio_image)
+    oiio.ImageBufAlgo.max(oiio_image_buf, oiio_image_buf, 0.0)
+    oiio.ImageBufAlgo.min(oiio_image_buf, oiio_image_buf, 1.0)
+    oiio_image = oiio_image_buf.get_pixels(format=oiio.FLOAT)
 
     return (oiio_image, h, w, pixelAspectRatio, orientation)
 
@@ -152,16 +100,30 @@ def writeImage(imagePath: str, image: np.ndarray, h_tgt: int, w_tgt: int, orient
         image = oiio_image_buf.get_pixels(format=oiio.FLOAT)
         w = w_tgt
         h = h_tgt
-    output_image = oiio.ImageOutput.create(imagePath)
-    output_image_spec = oiio.ImageSpec(w, h, c, oiio.UINT8)
-    if imagePath[-4:].lower() == ".exr":
-        output_image_spec.attribute('compression', 'zips') # required to get zip (1 scanline) compression method
-    output_image_spec.attribute('pixelAspectRatio', pixelAspectRatio)
-    output_image_spec.attribute('Orientation', orientation)
-    output_image.open(imagePath, output_image_spec)
 
-    output_image.write_image(image)
-    output_image.close()
+    if image.dtype == 'uint8':
+        if c == 1:
+            av_image = avimg.Image_uchar()
+        elif c == 3:
+            av_image = avimg.Image_RGBColor()
+        else:
+            av_image = avimg.Image_RGBAColor()
+    else:
+        if image.dtype != 'float32':
+            image = image.astype('float32')
+        if c == 1:
+            av_image = avimg.Image_float()
+        elif c == 3:
+            av_image = avimg.Image_RGBfColor()
+        else:
+            av_image = avimg.Image_RGBAfColor()
+    av_image.fromNumpyArray(image)
+
+    optWrite = avimg.ImageWriteOptions()
+    optWrite.toColorSpace(avimg.EImageColorSpace_NO_CONVERSION)
+    compression = "zips" if imagePath[-4:].lower() == ".exr" else ""
+    oiio_params = avimg.oiioParams(orientation, pixelAspectRatio, compression)
+    avimg.writeImage(imagePath, av_image, optWrite, oiio_params.get())
 
 def loadSequence(sequencePath: str, incolorspace: str = 'acescg', start: int = 0, stop: int = -1, verbose = False):
     rawfiles = []


### PR DESCRIPTION
This PR updates the image IOs by using the AV Python binding instead of reading through OpenImageIO.

Color spaces are now managed in the same way as they are in AliceVision C++ native nodes.

When reading an image, the metadata are still loaded using OpenImageIO.

This PR requires having the PR https://github.com/alicevision/AliceVision/pull/1899 merged into AliceVision before being merged in order to be able writing the OpenImageIO metadata 'Orientation', 'pixelAspectRatio' and 'Compression' to the image.