### PR TITLE
[meshroom] Rename `Publish` node to `ExportFiles`

### DIFF
--- a/meshroom/imageSegmentation.mg
+++ b/meshroom/imageSegmentation.mg
@@ -4,9 +4,9 @@
         "fileVersion": "2.0",
         "nodesVersions": {
             "CameraInit": "12.0",
+            "ExportFiles": "1.3",
             "ImageDetectionPrompt": "0.1",
-            "ImageSegmentationBox": "0.2",
-            "Publish": "1.3"
+            "ImageSegmentationBox": "0.2"
         },
         "template": true
     },
@@ -41,8 +41,8 @@
                 "keepFilename": true
             }
         },
-        "Publish_1": {
-            "nodeType": "Publish",
+        "ExportFiles_1": {
+            "nodeType": "ExportFiles",
             "position": [
                 600,
                 0


### PR DESCRIPTION
> [!WARNING]
> This should be merged with https://github.com/alicevision/Meshroom/pull/2868.

This PR renames the `Publish` node from the "Image Segmentation" to `ExportFiles`.