### PR TITLE
Enable folder input for all nodes

### DIFF
--- a/meshroom/imageSegmentation/ImageDetectionPrompt.py
+++ b/meshroom/imageSegmentation/ImageDetectionPrompt.py
@@ -8,22 +8,22 @@ from meshroom.core.utils import VERBOSE_LEVEL
 
 class ImageDetectionPromptNodeSize(desc.MultiDynamicNodeSize):
     def computeSize(self, node):
+        if node.attribute(self._params[0]).isLink:
+            return node.attribute(self._params[0]).inputLink.node.size
+
         from pathlib import Path
-        import itertools
 
         input_path_param = node.attribute(self._params[0])
         extension_param = node.attribute(self._params[1])
-
         input_path = input_path_param.value
         extension = extension_param.value
         include_suffixes = [extension.lower(), extension.upper()]
 
         size = 1
         if Path(input_path).is_dir():
+            import itertools
             image_paths = list(itertools.chain(*(Path(input_path).glob(f'*.{suffix}') for suffix in include_suffixes)))
             size = len(image_paths)
-        elif node.attribute(self._params[0]).isLink:
-            size = node.attribute(self._params[0]).inputLink.node.size
         
         return size
 

--- a/meshroom/imageSegmentation/ImageDetectionPrompt.py
+++ b/meshroom/imageSegmentation/ImageDetectionPrompt.py
@@ -1,13 +1,34 @@
-__version__ = "0.1"
+__version__ = "0.2"
 
 import os
+from pathlib import Path
 
 from meshroom.core import desc
 from meshroom.core.utils import VERBOSE_LEVEL
 
+class ImageDetectionPromptNodeSize(desc.MultiDynamicNodeSize):
+    def computeSize(self, node):
+        from pathlib import Path
+        import itertools
+
+        input_path_param = node.attribute(self._params[0])
+        extension_param = node.attribute(self._params[1])
+
+        input_path = input_path_param.value
+        extension = extension_param.value
+        include_suffixes = [extension.lower(), extension.upper()]
+
+        size = 1
+        if Path(input_path).is_dir():
+            image_paths = list(itertools.chain(*(Path(input_path).glob(f'*.{suffix}') for suffix in include_suffixes)))
+            size = len(image_paths)
+        elif node.attribute(self._params[0]).isLink:
+            size = node.attribute(self._params[0]).inputLink.node.size
+        
+        return size
 
 class ImageDetectionPrompt(desc.Node):
-    size = desc.DynamicNodeSize("input")
+    size = ImageDetectionPromptNodeSize(['input', 'extensionIn'])
     gpu = desc.Level.INTENSIVE
     parallelization = desc.Parallelization(blockSize=50)
 
@@ -25,8 +46,19 @@ Bounded box sizes can be increased by a ratio from 0 to 100%.
         desc.File(
             name="input",
             label="Input",
-            description="SfMData file input.",
+            description="Folder or SfMData file.",
             value="",
+        ),
+        desc.ChoiceParam(
+            name="extensionIn",
+            label="Input File Extension",
+            description="Input image file extension.\n"
+                        "Considered only if input is a folder.",
+            value="exr",
+            values=["exr", "png", "jpg"],
+            exclusive=True,
+            group="",  # remove from command line params
+            enabled=lambda node: Path(node.chunk.input.value).is_dir(),
         ),
         desc.File(
             name="recognitionModelPath",
@@ -101,7 +133,7 @@ Bounded box sizes can be increased by a ratio from 0 to 100%.
             enabled=lambda node: node.outputBboxImage.value,
         ),
         desc.ChoiceParam(
-            name="extension",
+            name="extensionOut",
             label="Output File Extension",
             description="Output image file extension.",
             value="jpg",
@@ -132,30 +164,41 @@ Bounded box sizes can be increased by a ratio from 0 to 100%.
             label="BBoxes",
             description="Generated images with bounded boxes baked in.",
             semantic="image",
-            value=lambda attr: "{nodeCacheFolder}/" + ("<FILESTEM>" if attr.node.keepFilename.value else "<VIEW_ID>") + "." + attr.node.extension.value,
+            value=lambda attr: "{nodeCacheFolder}/" + ("<FILESTEM>" if attr.node.keepFilename.value else "<VIEW_ID>") + "." + attr.node.extensionOut.value,
             enabled=lambda node: node.outputBboxImage.value,
             group="",
         ),
     ]
 
-    def resolvedPaths(self, inputSfm, outDir, keepFilename, ext):
+    def resolvedPaths(self, input_path, extensionIn, outDir, keepFilename, extensionOut):
         from pyalicevision import sfmData
         from pyalicevision import sfmDataIO
         from pathlib import Path
+        import itertools
 
+        include_suffixes = [extensionIn.lower(), extensionIn.upper()]
         paths = {}
-        dataAV = sfmData.SfMData()
-        if sfmDataIO.load(dataAV, inputSfm, sfmDataIO.ALL) and os.path.isdir(outDir):
-            views = dataAV.getViews()
-            for id, v in views.items():
-                inputFile = v.getImage().getImagePath()
-                if keepFilename:
-                    outputFileMask = os.path.join(outDir, Path(inputFile).stem + "." + ext)
-                    outputFileBoxes = os.path.join(outDir, Path(inputFile).stem + "_bboxes" + ".jpg")
-                else:
-                    outputFileMask = os.path.join(outDir, str(id) + "." + ext)
-                    outputFileBoxes = os.path.join(outDir, str(id) + "_bboxes" + ".jpg")
-                paths[inputFile] = (outputFileMask, outputFileBoxes)
+        if Path(input_path).is_dir():
+            input_filepaths = sorted(itertools.chain(*(Path(input_path).glob(f'*.{suffix}') for suffix in include_suffixes)))
+            for frameId, inputFile in enumerate(input_filepaths):
+                outputFileMask = os.path.join(outDir, Path(inputFile).stem + "." + extensionOut)
+                outputFileBoxes = os.path.join(outDir, "bboxes_" + Path(inputFile).stem + ".jpg")
+                paths[str(inputFile)] = (outputFileMask, outputFileBoxes, frameId)
+        elif Path(input_path).suffix.lower() in [".sfm", ".abc"]:
+            if Path(input_path).exists():
+                dataAV = sfmData.SfMData()
+                if sfmDataIO.load(dataAV, input_path, sfmDataIO.ALL) and os.path.isdir(outDir):
+                    views = dataAV.getViews()
+                    for id, v in views.items():
+                        inputFile = v.getImage().getImagePath()
+                        frameId = v.getFrameId()
+                        if keepFilename:
+                            outputFileMask = os.path.join(outDir, Path(inputFile).stem + "." + extensionOut)
+                            outputFileBoxes = os.path.join(outDir, "bboxes_" + Path(inputFile).stem + ".jpg")
+                        else:
+                            outputFileMask = os.path.join(outDir, str(id) + "." + extensionOut)
+                            outputFileBoxes = os.path.join(outDir, "bboxes_" + str(id) + ".jpg")
+                        paths[inputFile] = (outputFileMask, outputFileBoxes, frameId)
 
         return paths
 
@@ -176,7 +219,7 @@ Bounded box sizes can be increased by a ratio from 0 to 100%.
 
             chunk.logger.info("Chunk range from {} to {}".format(chunk.range.start, chunk.range.last))
 
-            outFiles = self.resolvedPaths(chunk.node.input.value, chunk.node.output.value, chunk.node.keepFilename.value, chunk.node.extension.value)
+            outFiles = self.resolvedPaths(chunk.node.input.value, chunk.node.extensionIn.value, chunk.node.output.value, chunk.node.keepFilename.value, chunk.node.extensionOut.value)
 
             if not os.path.exists(chunk.node.output.value):
                 os.mkdir(chunk.node.output.value)

--- a/meshroom/imageSegmentation/ImageDetectionPrompt.py
+++ b/meshroom/imageSegmentation/ImageDetectionPrompt.py
@@ -58,7 +58,7 @@ Bounded box sizes can be increased by a ratio from 0 to 100%.
             values=["exr", "png", "jpg"],
             exclusive=True,
             group="",  # remove from command line params
-            enabled=lambda node: Path(node.chunk.input.value).is_dir(),
+            enabled=lambda node: Path(node.input.value).is_dir(),
         ),
         desc.File(
             name="recognitionModelPath",
@@ -130,7 +130,7 @@ Bounded box sizes can be increased by a ratio from 0 to 100%.
             label="Keep Filename",
             description="Keep the filename of the inputs for the outputs.",
             value=False,
-            enabled=lambda node: node.outputBboxImage.value,
+            enabled=lambda node: node.outputBboxImage.value and not Path(node.input.value).is_dir(),
         ),
         desc.ChoiceParam(
             name="extensionOut",

--- a/meshroom/imageSegmentation/ImageSegmentationBox.py
+++ b/meshroom/imageSegmentation/ImageSegmentationBox.py
@@ -8,24 +8,25 @@ from meshroom.core.utils import VERBOSE_LEVEL
 
 class ImageSegmentationBoxNodeSize(desc.MultiDynamicNodeSize):
     def computeSize(self, node):
+        if node.attribute(self._params[0]).isLink:
+            return node.attribute(self._params[0]).inputLink.node.size
+
         from pathlib import Path
-        import itertools
 
         input_path_param = node.attribute(self._params[0])
         extension_param = node.attribute(self._params[1])
-
         input_path = input_path_param.value
         extension = extension_param.value
         include_suffixes = [extension.lower(), extension.upper()]
 
         size = 1
         if Path(input_path).is_dir():
+            import itertools
             image_paths = list(itertools.chain(*(Path(input_path).glob(f'*.{suffix}') for suffix in include_suffixes)))
             size = len(image_paths)
-        elif node.attribute(self._params[0]).isLink:
-            size = node.attribute(self._params[0]).inputLink.node.size
         
         return size
+        
 class ImageSegmentationBox(desc.Node):
     size = ImageSegmentationBoxNodeSize(['input', 'extensionIn'])
     gpu = desc.Level.INTENSIVE

--- a/meshroom/imageSegmentation/ImageSegmentationBox.py
+++ b/meshroom/imageSegmentation/ImageSegmentationBox.py
@@ -64,7 +64,7 @@ In case neither tracker nor json file is available, the model is applied on the 
             values=["exr", "png", "jpg"],
             exclusive=True,
             group="",  # remove from command line params
-            enabled=lambda node: Path(node.chunk.input.value).is_dir(),
+            enabled=lambda node: Path(node.input.value).is_dir(),
         ),
         desc.File(
             name="bboxFolder",
@@ -102,6 +102,7 @@ In case neither tracker nor json file is available, the model is applied on the 
             label="Keep Filename",
             description="Keep the filename of the inputs for the outputs.",
             value=False,
+            enabled=lambda node: not Path(node.input.value).is_dir(),
         ),
         desc.ChoiceParam(
             name="extensionOut",

--- a/meshroom/imageSegmentation/ImageSegmentationBox.py
+++ b/meshroom/imageSegmentation/ImageSegmentationBox.py
@@ -1,13 +1,33 @@
-__version__ = "0.2"
+__version__ = "0.3"
 
 import os
+from pathlib import Path
 
 from meshroom.core import desc
 from meshroom.core.utils import VERBOSE_LEVEL
 
+class ImageSegmentationBoxNodeSize(desc.MultiDynamicNodeSize):
+    def computeSize(self, node):
+        from pathlib import Path
+        import itertools
 
+        input_path_param = node.attribute(self._params[0])
+        extension_param = node.attribute(self._params[1])
+
+        input_path = input_path_param.value
+        extension = extension_param.value
+        include_suffixes = [extension.lower(), extension.upper()]
+
+        size = 1
+        if Path(input_path).is_dir():
+            image_paths = list(itertools.chain(*(Path(input_path).glob(f'*.{suffix}') for suffix in include_suffixes)))
+            size = len(image_paths)
+        elif node.attribute(self._params[0]).isLink:
+            size = node.attribute(self._params[0]).inputLink.node.size
+        
+        return size
 class ImageSegmentationBox(desc.Node):
-    size = desc.DynamicNodeSize("input")
+    size = ImageSegmentationBoxNodeSize(['input', 'extensionIn'])
     gpu = desc.Level.INTENSIVE
     parallelization = desc.Parallelization(blockSize=50)
 
@@ -32,8 +52,19 @@ In case neither tracker nor json file is available, the model is applied on the 
         desc.File(
             name="input",
             label="Input",
-            description="SfMData file input.",
+            description="Folder or SfMData file.",
             value="",
+        ),
+        desc.ChoiceParam(
+            name="extensionIn",
+            label="Input File Extension",
+            description="Input image file extension.\n"
+                        "Considered only if input is a folder.",
+            value="exr",
+            values=["exr", "png", "jpg"],
+            exclusive=True,
+            group="",  # remove from command line params
+            enabled=lambda node: Path(node.chunk.input.value).is_dir(),
         ),
         desc.File(
             name="bboxFolder",
@@ -73,7 +104,7 @@ In case neither tracker nor json file is available, the model is applied on the 
             value=False,
         ),
         desc.ChoiceParam(
-            name="extension",
+            name="extensionOut",
             label="Output File Extension",
             description="Output image file extension.\n"
                         "If unset, the output file extension will match the input's if possible.",
@@ -110,7 +141,7 @@ In case neither tracker nor json file is available, the model is applied on the 
             label="Masks",
             description="Generated segmentation masks.",
             semantic="image",
-            value=lambda attr: "{nodeCacheFolder}/" + ("<FILESTEM>" if attr.node.keepFilename.value else "<VIEW_ID>") + "." + attr.node.extension.value,
+            value=lambda attr: "{nodeCacheFolder}/" + ("<FILESTEM>" if attr.node.keepFilename.value else "<VIEW_ID>") + "." + attr.node.extensionOut.value,
             group="",
         ),
         desc.File(
@@ -124,25 +155,35 @@ In case neither tracker nor json file is available, the model is applied on the 
         ),
     ]
 
-    def resolvedPaths(self, inputSfm, outDir, keepFilename, extension):
+    def resolvedPaths(self, input_path, extensionIn, outDir, keepFilename, extensionOut):
         from pyalicevision import sfmData
         from pyalicevision import sfmDataIO
         from pathlib import Path
+        import itertools
 
+        include_suffixes = [extensionIn.lower(), extensionIn.upper()]
         paths = {}
-        dataAV = sfmData.SfMData()
-        if sfmDataIO.load(dataAV, inputSfm, sfmDataIO.ALL) and os.path.isdir(outDir):
-            views = dataAV.getViews()
-            for id, v in views.items():
-                inputFile = v.getImage().getImagePath()
-                frameId = v.getFrameId()
-                if keepFilename:
-                    outputFileMask = os.path.join(outDir, Path(inputFile).stem + "." + extension)
-                    outputFileBoxes = os.path.join(outDir, "bboxes_" + Path(inputFile).stem + ".jpg")
-                else:
-                    outputFileMask = os.path.join(outDir, str(id) + "." + extension)
-                    outputFileBoxes = os.path.join(outDir, "bboxes_" + str(id) + ".jpg")
-                paths[inputFile] = (outputFileMask, outputFileBoxes, frameId)
+        if Path(input_path).is_dir():
+            input_filepaths = sorted(itertools.chain(*(Path(input_path).glob(f'*.{suffix}') for suffix in include_suffixes)))
+            for frameId, inputFile in enumerate(input_filepaths):
+                outputFileMask = os.path.join(outDir, Path(inputFile).stem + "." + extensionOut)
+                outputFileBoxes = os.path.join(outDir, "bboxes_" + Path(inputFile).stem + ".jpg")
+                paths[str(inputFile)] = (outputFileMask, outputFileBoxes, frameId)
+        elif Path(input_path).suffix.lower() in [".sfm", ".abc"]:
+            if Path(input_path).exists():
+                dataAV = sfmData.SfMData()
+                if sfmDataIO.load(dataAV, input_path, sfmDataIO.ALL) and os.path.isdir(outDir):
+                    views = dataAV.getViews()
+                    for id, v in views.items():
+                        inputFile = v.getImage().getImagePath()
+                        frameId = v.getFrameId()
+                        if keepFilename:
+                            outputFileMask = os.path.join(outDir, Path(inputFile).stem + "." + extensionOut)
+                            outputFileBoxes = os.path.join(outDir, "bboxes_" + Path(inputFile).stem + ".jpg")
+                        else:
+                            outputFileMask = os.path.join(outDir, str(id) + "." + extensionOut)
+                            outputFileBoxes = os.path.join(outDir, "bboxes_" + str(id) + ".jpg")
+                        paths[inputFile] = (outputFileMask, outputFileBoxes, frameId)
 
         return paths
 
@@ -170,7 +211,7 @@ In case neither tracker nor json file is available, the model is applied on the 
 
             chunk.logger.info("Chunk range from {} to {}".format(chunk.range.start, chunk.range.last))
 
-            outFiles = self.resolvedPaths(chunk.node.input.value, chunk.node.output.value, chunk.node.keepFilename.value, chunk.node.extension.value)
+            outFiles = self.resolvedPaths(chunk.node.input.value, chunk.node.extensionIn.value, chunk.node.output.value, chunk.node.keepFilename.value, chunk.node.extensionOut.value)
 
             if not os.path.exists(chunk.node.output.value):
                 os.mkdir(chunk.node.output.value)

--- a/meshroom/imageSegmentation/ImageSegmentationPrompt.py
+++ b/meshroom/imageSegmentation/ImageSegmentationPrompt.py
@@ -58,7 +58,7 @@ Bounded box sizes can be increased by a ratio from 0 to 100%.
             values=["exr", "png", "jpg"],
             exclusive=True,
             group="",  # remove from command line params
-            enabled=lambda node: Path(node.chunk.input.value).is_dir(),
+            enabled=lambda node: Path(node.input.value).is_dir(),
         ),
         desc.File(
             name="recognitionModelPath",
@@ -136,6 +136,7 @@ Bounded box sizes can be increased by a ratio from 0 to 100%.
             label="Keep Filename",
             description="Keep the filename of the inputs for the outputs.",
             value=False,
+            enabled=lambda node: not Path(node.input.value).is_dir(),
         ),
         desc.ChoiceParam(
             name="extensionOut",

--- a/meshroom/imageSegmentation/ImageSegmentationPrompt.py
+++ b/meshroom/imageSegmentation/ImageSegmentationPrompt.py
@@ -8,22 +8,22 @@ from meshroom.core.utils import VERBOSE_LEVEL
 
 class ImageSegmentationPromptNodeSize(desc.MultiDynamicNodeSize):
     def computeSize(self, node):
+        if node.attribute(self._params[0]).isLink:
+            return node.attribute(self._params[0]).inputLink.node.size
+
         from pathlib import Path
-        import itertools
 
         input_path_param = node.attribute(self._params[0])
         extension_param = node.attribute(self._params[1])
-
         input_path = input_path_param.value
         extension = extension_param.value
         include_suffixes = [extension.lower(), extension.upper()]
 
         size = 1
         if Path(input_path).is_dir():
+            import itertools
             image_paths = list(itertools.chain(*(Path(input_path).glob(f'*.{suffix}') for suffix in include_suffixes)))
             size = len(image_paths)
-        elif node.attribute(self._params[0]).isLink:
-            size = node.attribute(self._params[0]).inputLink.node.size
         
         return size
 

--- a/meshroom/imageSegmentation/ImageSegmentationPrompt.py
+++ b/meshroom/imageSegmentation/ImageSegmentationPrompt.py
@@ -1,13 +1,34 @@
-__version__ = "0.1"
+__version__ = "0.2"
 
 import os
+from pathlib import Path
 
 from meshroom.core import desc
 from meshroom.core.utils import VERBOSE_LEVEL
 
+class ImageSegmentationPromptNodeSize(desc.MultiDynamicNodeSize):
+    def computeSize(self, node):
+        from pathlib import Path
+        import itertools
+
+        input_path_param = node.attribute(self._params[0])
+        extension_param = node.attribute(self._params[1])
+
+        input_path = input_path_param.value
+        extension = extension_param.value
+        include_suffixes = [extension.lower(), extension.upper()]
+
+        size = 1
+        if Path(input_path).is_dir():
+            image_paths = list(itertools.chain(*(Path(input_path).glob(f'*.{suffix}') for suffix in include_suffixes)))
+            size = len(image_paths)
+        elif node.attribute(self._params[0]).isLink:
+            size = node.attribute(self._params[0]).inputLink.node.size
+        
+        return size
 
 class ImageSegmentationPrompt(desc.Node):
-    size = desc.DynamicNodeSize("input")
+    size = ImageSegmentationPromptNodeSize(['input', 'extensionIn'])
     gpu = desc.Level.INTENSIVE
     parallelization = desc.Parallelization(blockSize=50)
 
@@ -25,8 +46,19 @@ Bounded box sizes can be increased by a ratio from 0 to 100%.
         desc.File(
             name="input",
             label="Input",
-            description="SfMData file input.",
+            description="Folder or SfMData file.",
             value="",
+        ),
+        desc.ChoiceParam(
+            name="extensionIn",
+            label="Input File Extension",
+            description="Input image file extension.\n"
+                        "Considered only if input is a folder.",
+            value="exr",
+            values=["exr", "png", "jpg"],
+            exclusive=True,
+            group="",  # remove from command line params
+            enabled=lambda node: Path(node.chunk.input.value).is_dir(),
         ),
         desc.File(
             name="recognitionModelPath",
@@ -106,7 +138,7 @@ Bounded box sizes can be increased by a ratio from 0 to 100%.
             value=False,
         ),
         desc.ChoiceParam(
-            name="extension",
+            name="extensionOut",
             label="Output File Extension",
             description="Output image file extension.\n"
                         "If unset, the output file extension will match the input's if possible.",
@@ -143,7 +175,7 @@ Bounded box sizes can be increased by a ratio from 0 to 100%.
             label="Masks",
             description="Generated segmentation masks.",
             semantic="image",
-            value=lambda attr: "{nodeCacheFolder}/" + ("<FILESTEM>" if attr.node.keepFilename.value else "<VIEW_ID>") + "." + attr.node.extension.value,
+            value=lambda attr: "{nodeCacheFolder}/" + ("<FILESTEM>" if attr.node.keepFilename.value else "<VIEW_ID>") + "." + attr.node.extensionOut.value,
             group="",
         ),
         desc.File(
@@ -157,24 +189,35 @@ Bounded box sizes can be increased by a ratio from 0 to 100%.
         ),
     ]
 
-    def resolvedPaths(self, inputSfm, outDir, keepFilename, ext):
+    def resolvedPaths(self, input_path, extensionIn, outDir, keepFilename, extensionOut):
         from pyalicevision import sfmData
         from pyalicevision import sfmDataIO
         from pathlib import Path
+        import itertools
 
+        include_suffixes = [extensionIn.lower(), extensionIn.upper()]
         paths = {}
-        dataAV = sfmData.SfMData()
-        if sfmDataIO.load(dataAV, inputSfm, sfmDataIO.ALL) and os.path.isdir(outDir):
-            views = dataAV.getViews()
-            for id, v in views.items():
-                inputFile = v.getImage().getImagePath()
-                if keepFilename:
-                    outputFileMask = os.path.join(outDir, Path(inputFile).stem + "." + ext)
-                    outputFileBoxes = os.path.join(outDir, Path(inputFile).stem + "_bboxes" + ".jpg")
-                else:
-                    outputFileMask = os.path.join(outDir, str(id) + "." + ext)
-                    outputFileBoxes = os.path.join(outDir, str(id) + "_bboxes" + ".jpg")
-                paths[inputFile] = (outputFileMask, outputFileBoxes)
+        if Path(input_path).is_dir():
+            input_filepaths = sorted(itertools.chain(*(Path(input_path).glob(f'*.{suffix}') for suffix in include_suffixes)))
+            for frameId, inputFile in enumerate(input_filepaths):
+                outputFileMask = os.path.join(outDir, Path(inputFile).stem + "." + extensionOut)
+                outputFileBoxes = os.path.join(outDir, "bboxes_" + Path(inputFile).stem + ".jpg")
+                paths[str(inputFile)] = (outputFileMask, outputFileBoxes, frameId)
+        elif Path(input_path).suffix.lower() in [".sfm", ".abc"]:
+            if Path(input_path).exists():
+                dataAV = sfmData.SfMData()
+                if sfmDataIO.load(dataAV, input_path, sfmDataIO.ALL) and os.path.isdir(outDir):
+                    views = dataAV.getViews()
+                    for id, v in views.items():
+                        inputFile = v.getImage().getImagePath()
+                        frameId = v.getFrameId()
+                        if keepFilename:
+                            outputFileMask = os.path.join(outDir, Path(inputFile).stem + "." + extensionOut)
+                            outputFileBoxes = os.path.join(outDir, "bboxes_" + Path(inputFile).stem + ".jpg")
+                        else:
+                            outputFileMask = os.path.join(outDir, str(id) + "." + extensionOut)
+                            outputFileBoxes = os.path.join(outDir, "bboxes_" + str(id) + ".jpg")
+                        paths[inputFile] = (outputFileMask, outputFileBoxes, frameId)
 
         return paths
 
@@ -194,7 +237,7 @@ Bounded box sizes can be increased by a ratio from 0 to 100%.
 
             chunk.logger.info("Chunk range from {} to {}".format(chunk.range.start, chunk.range.last))
 
-            outFiles = self.resolvedPaths(chunk.node.input.value, chunk.node.output.value, chunk.node.keepFilename.value, chunk.node.extension.value)
+            outFiles = self.resolvedPaths(chunk.node.input.value, chunk.node.extensionIn.value, chunk.node.output.value, chunk.node.keepFilename.value, chunk.node.extensionOut.value)
 
             if not os.path.exists(chunk.node.output.value):
                 os.mkdir(chunk.node.output.value)

--- a/meshroom/imageSegmentation/ImageTagsExtraction.py
+++ b/meshroom/imageSegmentation/ImageTagsExtraction.py
@@ -53,7 +53,7 @@ Generate a set of tags corresponding to recognized elements using a recognition 
             values=["exr", "png", "jpg"],
             exclusive=True,
             group="",  # remove from command line params
-            enabled=lambda node: Path(node.chunk.input.value).is_dir(),
+            enabled=lambda node: Path(node.input.value).is_dir(),
         ),
         desc.File(
             name="recognitionModelPath",
@@ -79,7 +79,7 @@ Generate a set of tags corresponding to recognized elements using a recognition 
             label="Keep Filename",
             description="Keep the filename of the inputs for the outputs.",
             value=False,
-            enabled=lambda node: node.outputTaggedImage.value,
+            enabled=lambda node: node.outputTaggedImage.value and not Path(node.input.value).is_dir(),
         ),
         desc.ChoiceParam(
             name="extensionOut",

--- a/meshroom/imageSegmentation/ImageTagsExtraction.py
+++ b/meshroom/imageSegmentation/ImageTagsExtraction.py
@@ -1,12 +1,34 @@
-__version__ = "0.1"
+__version__ = "0.2"
 
 import os
+from pathlib import Path
 
 from meshroom.core import desc
 from meshroom.core.utils import VERBOSE_LEVEL
 
+class ImageTagsExtractionNodeSize(desc.MultiDynamicNodeSize):
+    def computeSize(self, node):
+        from pathlib import Path
+        import itertools
+
+        input_path_param = node.attribute(self._params[0])
+        extension_param = node.attribute(self._params[1])
+
+        input_path = input_path_param.value
+        extension = extension_param.value
+        include_suffixes = [extension.lower(), extension.upper()]
+
+        size = 1
+        if Path(input_path).is_dir():
+            image_paths = list(itertools.chain(*(Path(input_path).glob(f'*.{suffix}') for suffix in include_suffixes)))
+            size = len(image_paths)
+        elif node.attribute(self._params[0]).isLink:
+            size = node.attribute(self._params[0]).inputLink.node.size
+        
+        return size
+
 class ImageTagsExtraction(desc.Node):
-    size = desc.DynamicNodeSize("input")
+    size = ImageTagsExtractionNodeSize(['input', 'extensionIn'])
     gpu = desc.Level.INTENSIVE
     parallelization = desc.Parallelization(blockSize=50)
 
@@ -19,8 +41,19 @@ Generate a set of tags corresponding to recognized elements using a recognition 
         desc.File(
             name="input",
             label="Input",
-            description="SfMData file input.",
+            description="Folder or SfMData file.",
             value="",
+        ),
+        desc.ChoiceParam(
+            name="extensionIn",
+            label="Input File Extension",
+            description="Input image file extension.\n"
+                        "Considered only if input is a folder.",
+            value="exr",
+            values=["exr", "png", "jpg"],
+            exclusive=True,
+            group="",  # remove from command line params
+            enabled=lambda node: Path(node.chunk.input.value).is_dir(),
         ),
         desc.File(
             name="recognitionModelPath",
@@ -49,7 +82,7 @@ Generate a set of tags corresponding to recognized elements using a recognition 
             enabled=lambda node: node.outputTaggedImage.value,
         ),
         desc.ChoiceParam(
-            name="extension",
+            name="extensionOut",
             label="Output File Extension",
             description="Output image file extension.",
             value="jpg",
@@ -80,29 +113,40 @@ Generate a set of tags corresponding to recognized elements using a recognition 
             label="Results",
             description="Generated images.",
             semantic="image",
-            value=lambda attr: "{nodeCacheFolder}/" + ("<FILESTEM>" if attr.node.keepFilename.value else "<VIEW_ID>") + "." + attr.node.extension.value,
+            value=lambda attr: "{nodeCacheFolder}/" + ("<FILESTEM>" if attr.node.keepFilename.value else "<VIEW_ID>") + "." + attr.node.extensionOut.value,
             group="",
         ),
     ]
 
-    def resolvedPaths(self, inputSfm, outDir, keepFilename, ext):
+    def resolvedPaths(self, input_path, extensionIn, outDir, keepFilename, extensionOut):
         from pyalicevision import sfmData
         from pyalicevision import sfmDataIO
         from pathlib import Path
+        import itertools
 
+        include_suffixes = [extensionIn.lower(), extensionIn.upper()]
         paths = {}
-        dataAV = sfmData.SfMData()
-        if sfmDataIO.load(dataAV, inputSfm, sfmDataIO.ALL) and os.path.isdir(outDir):
-            views = dataAV.getViews()
-            for id, v in views.items():
-                inputFile = v.getImage().getImagePath()
-                if keepFilename:
-                    outputFileMask = os.path.join(outDir, Path(inputFile).stem + "." + ext)
-                    outputFileBoxes = os.path.join(outDir, Path(inputFile).stem + "_bboxes" + ".jpg")
-                else:
-                    outputFileMask = os.path.join(outDir, str(id) + "." + ext)
-                    outputFileBoxes = os.path.join(outDir, str(id) + "_bboxes" + ".jpg")
-                paths[inputFile] = (outputFileMask, outputFileBoxes)
+        if Path(input_path).is_dir():
+            input_filepaths = sorted(itertools.chain(*(Path(input_path).glob(f'*.{suffix}') for suffix in include_suffixes)))
+            for frameId, inputFile in enumerate(input_filepaths):
+                outputFileMask = os.path.join(outDir, Path(inputFile).stem + "." + extensionOut)
+                outputFileBoxes = os.path.join(outDir, "bboxes_" + Path(inputFile).stem + ".jpg")
+                paths[str(inputFile)] = (outputFileMask, outputFileBoxes, frameId)
+        elif Path(input_path).suffix.lower() in [".sfm", ".abc"]:
+            if Path(input_path).exists():
+                dataAV = sfmData.SfMData()
+                if sfmDataIO.load(dataAV, input_path, sfmDataIO.ALL) and os.path.isdir(outDir):
+                    views = dataAV.getViews()
+                    for id, v in views.items():
+                        inputFile = v.getImage().getImagePath()
+                        frameId = v.getFrameId()
+                        if keepFilename:
+                            outputFileMask = os.path.join(outDir, Path(inputFile).stem + "." + extensionOut)
+                            outputFileBoxes = os.path.join(outDir, "bboxes_" + Path(inputFile).stem + ".jpg")
+                        else:
+                            outputFileMask = os.path.join(outDir, str(id) + "." + extensionOut)
+                            outputFileBoxes = os.path.join(outDir, "bboxes_" + str(id) + ".jpg")
+                        paths[inputFile] = (outputFileMask, outputFileBoxes, frameId)
 
         return paths
 
@@ -123,7 +167,7 @@ Generate a set of tags corresponding to recognized elements using a recognition 
 
             chunk.logger.info("Chunk range from {} to {}".format(chunk.range.start, chunk.range.last))
 
-            outFiles = self.resolvedPaths(chunk.node.input.value, chunk.node.output.value, chunk.node.keepFilename.value, chunk.node.extension.value)
+            outFiles = self.resolvedPaths(chunk.node.input.value, chunk.node.extensionIn.value, chunk.node.output.value, chunk.node.keepFilename.value, chunk.node.extensionOut.value)
 
             if not os.path.exists(chunk.node.output.value):
                 os.mkdir(chunk.node.output.value)

--- a/meshroom/imageSegmentation/ImageTagsExtraction.py
+++ b/meshroom/imageSegmentation/ImageTagsExtraction.py
@@ -8,22 +8,22 @@ from meshroom.core.utils import VERBOSE_LEVEL
 
 class ImageTagsExtractionNodeSize(desc.MultiDynamicNodeSize):
     def computeSize(self, node):
+        if node.attribute(self._params[0]).isLink:
+            return node.attribute(self._params[0]).inputLink.node.size
+
         from pathlib import Path
-        import itertools
 
         input_path_param = node.attribute(self._params[0])
         extension_param = node.attribute(self._params[1])
-
         input_path = input_path_param.value
         extension = extension_param.value
         include_suffixes = [extension.lower(), extension.upper()]
 
         size = 1
         if Path(input_path).is_dir():
+            import itertools
             image_paths = list(itertools.chain(*(Path(input_path).glob(f'*.{suffix}') for suffix in include_suffixes)))
             size = len(image_paths)
-        elif node.attribute(self._params[0]).isLink:
-            size = node.attribute(self._params[0]).inputLink.node.size
         
         return size
 


### PR DESCRIPTION
This pull request refactors the image segmentation and detection nodes to better support both folders and SfMData files as input, and improves flexibility for handling image file extensions. The main changes include introducing new dynamic node size classes that account for input extension, adding parameters for input and output file extensions, and updating logic throughout the nodes to use these parameters for file handling and path resolution.

**Dynamic node size and input handling improvements:**

* Introduced new `MultiDynamicNodeSize` subclasses (e.g., `ImageDetectionPromptNodeSize`, `ImageSegmentationBoxNodeSize`, `ImageSegmentationPromptNodeSize`, `ImageTagsExtractionNodeSize`) to compute node size based on both input path and input file extension, improving accuracy when input is a folder. (`meshroom/imageSegmentation/ImageDetectionPrompt.py`, `meshroom/imageSegmentation/ImageSegmentationBox.py`, `meshroom/imageSegmentation/ImageSegmentationPrompt.py`, `meshroom/imageSegmentation/ImageTagsExtraction.py`) [[1]](diffhunk://#diff-c44259f0b92fe4b82942672d725fb7e343915ef7e243ac7785cd6942fefc0263L1-R31) [[2]](diffhunk://#diff-9ccaafa4e967e10596c4044629a897eb9c22c82e037df9a363bad4386b3f951aL1-R30) [[3]](diffhunk://#diff-525fadada02fec8c6b132a5d3a11bc7f1230095567372c3a180428ac4346d89fL1-R31) [[4]](diffhunk://#diff-5ca7b7f8b0cf1411f30d79670f4554a35652ba0198c3f1309fdcad3cd4001648L1-R31)

* Updated node `size` attributes to use the new dynamic size classes that consider both `input` and `extensionIn` parameters. [[1]](diffhunk://#diff-c44259f0b92fe4b82942672d725fb7e343915ef7e243ac7785cd6942fefc0263L1-R31) [[2]](diffhunk://#diff-9ccaafa4e967e10596c4044629a897eb9c22c82e037df9a363bad4386b3f951aL1-R30) [[3]](diffhunk://#diff-525fadada02fec8c6b132a5d3a11bc7f1230095567372c3a180428ac4346d89fL1-R31) [[4]](diffhunk://#diff-5ca7b7f8b0cf1411f30d79670f4554a35652ba0198c3f1309fdcad3cd4001648L1-R31)

**Parameterization and file extension handling:**

* Added a new `extensionIn` parameter (as a `ChoiceParam`) to allow users to specify the input image file extension when the input is a folder, and updated descriptions for clarity. [[1]](diffhunk://#diff-c44259f0b92fe4b82942672d725fb7e343915ef7e243ac7785cd6942fefc0263L28-R62) [[2]](diffhunk://#diff-9ccaafa4e967e10596c4044629a897eb9c22c82e037df9a363bad4386b3f951aL35-R68) [[3]](diffhunk://#diff-525fadada02fec8c6b132a5d3a11bc7f1230095567372c3a180428ac4346d89fL28-R62)

* Renamed the output file extension parameter from `extension` to `extensionOut` for clarity and updated all references in output file naming and path resolution logic. [[1]](diffhunk://#diff-c44259f0b92fe4b82942672d725fb7e343915ef7e243ac7785cd6942fefc0263L104-R136) [[2]](diffhunk://#diff-9ccaafa4e967e10596c4044629a897eb9c22c82e037df9a363bad4386b3f951aL76-R107) [[3]](diffhunk://#diff-525fadada02fec8c6b132a5d3a11bc7f1230095567372c3a180428ac4346d89fL109-R141)

**Path resolution and chunk processing updates:**

* Refactored the `resolvedPaths` methods in all affected nodes to accept both input and output extension parameters, and updated logic to generate output file paths accordingly for both folder and SfMData/ABC file inputs. [[1]](diffhunk://#diff-c44259f0b92fe4b82942672d725fb7e343915ef7e243ac7785cd6942fefc0263L135-R201) [[2]](diffhunk://#diff-9ccaafa4e967e10596c4044629a897eb9c22c82e037df9a363bad4386b3f951aL127-R184) [[3]](diffhunk://#diff-525fadada02fec8c6b132a5d3a11bc7f1230095567372c3a180428ac4346d89fL160-R220)

* Updated `processChunk` methods to pass the new extension parameters when calling `resolvedPaths`. [[1]](diffhunk://#diff-c44259f0b92fe4b82942672d725fb7e343915ef7e243ac7785cd6942fefc0263L179-R222) [[2]](diffhunk://#diff-9ccaafa4e967e10596c4044629a897eb9c22c82e037df9a363bad4386b3f951aL173-R214) [[3]](diffhunk://#diff-525fadada02fec8c6b132a5d3a11bc7f1230095567372c3a180428ac4346d89fL197-R240)

These changes make the nodes more flexible and robust when handling various input types and image formats, and improve the maintainability of the codebase by unifying extension handling.