### PR TITLE
Add VideoSegmentationSam3Boxes node

### DIFF
--- a/meshroom/imageSegmentation/VideoSegmentationSam3Boxes.py
+++ b/meshroom/imageSegmentation/VideoSegmentationSam3Boxes.py
@@ -1,0 +1,300 @@
+__version__ = "1.0"
+
+from functools import total_ordering
+import os
+from pathlib import Path
+
+from meshroom.core import desc
+from meshroom.core.utils import VERBOSE_LEVEL
+from pyalicevision import parallelization as avpar
+
+import logging
+logger = logging.getLogger("VideoSegmentationSam3Boxes")
+
+class VideoSegmentationSam3Boxes(desc.Node):
+    size = avpar.DynamicViewsSize("input")
+    gpu = desc.Level.EXTREME
+
+    category = "Segmentation"
+    documentation = """
+Based on the Segment Anything video predictor model 3, the node generates binary masks from a set of
+bounding boxes contained in a json file.
+"""
+
+    inputs = [
+        desc.File(
+            name="input",
+            label="Input",
+            description="SfMData file.",
+            value="",
+        ),
+        desc.File(
+            name="inputx2",
+            label="Inputx2",
+            description="Folder containing source images upscale by 2.",
+            value="",
+        ),
+        desc.File(
+            name="inputx4",
+            label="Inputx4",
+            description="Folder containing source images upscale by 4.",
+            value="",
+        ),
+        desc.File(
+            name="masksFolder",
+            label="Masks Folder",
+            description="Folder containing the masks computed at original resolution.",
+            value="",
+        ),
+        desc.File(
+            name="bboxesFolder",
+            label="Bounding Boxes Folder",
+            description="Folder containing the bboxes.json file associated to the sfmData used as input.",
+            value="",
+        ),
+        desc.File(
+            name="segmentationModelPath",
+            label="Segmentation Model",
+            description="Weights file for the segmentation model.",
+            value="${RDS_SAM3_MODEL_PATH}",
+        ),
+        desc.BoolParam(
+            name="maskInvert",
+            label="Invert Masks",
+            description="Invert mask values. If selected, the pixels corresponding to the mask will be set to 0 instead of 255.",
+            value=False,
+        ),
+        desc.BoolParam(
+            name="useGpu",
+            label="Use GPU",
+            description="Use GPU for computation if available.",
+            value=True,
+            invalidate=False,
+        ),
+        desc.BoolParam(
+            name="keepFilename",
+            label="Keep Filename",
+            description="Keep the filename of the inputs for the outputs.",
+            value=True,
+        ),
+        desc.ChoiceParam(
+            name="extensionOut",
+            label="Output File Extension",
+            description="Output image file extension.\n"
+                        "If unset, the output file extension will match the input's if possible.",
+            value="exr",
+            values=["exr", "png", "jpg"],
+            exclusive=True,
+        ),
+        desc.ChoiceParam(
+            name="verboseLevel",
+            label="Verbose Level",
+            description="Verbosity level (fatal, error, warning, info, debug).",
+            value="info",
+            values=VERBOSE_LEVEL,
+            exclusive=True,
+        ),
+    ]
+
+    outputs = [
+        desc.File(
+            name="output",
+            label="Masks Folder",
+            description="Output path for the masks.",
+            value="{nodeCacheFolder}",
+        ),
+        desc.File(
+            name="masks",
+            label="Masks",
+            description="Generated segmentation masks.",
+            semantic="image",
+            value=lambda attr: "{nodeCacheFolder}/" + ("<FILESTEM>" if attr.node.keepFilename.value else "<VIEW_ID>") + "." + attr.node.extensionOut.value,
+        ),
+    ]
+
+    def preprocess(self, node):
+        import re
+        input_path = node.input.value
+        image_paths = get_image_paths_list(input_path, node.inputx2.value, node.inputx4.value)
+        if len(image_paths) == 0:
+            raise FileNotFoundError(f'No image files found in {input_path}')
+        self.image_paths = image_paths
+        if node.bboxesFolder.value == "":
+            raise ValueError(f'No file containing bounding boxes connected')
+
+    def processChunk(self, chunk):
+        from segmentationRDS import image, sam3Utils, bboxUtils
+        from sam3.model_builder import build_sam3_video_predictor
+        import numpy as np
+        import torch
+        from pyalicevision import image as avimg
+        from PIL import Image
+        import OpenImageIO as oiio
+
+        try:
+            logger.setLevel(chunk.node.verboseLevel.value.upper())
+
+            if not chunk.node.input:
+                logger.warning("Nothing to segment")
+                return
+            if not chunk.node.output.value:
+                return
+
+            logger.info("Chunk range from {} to {}".format(chunk.range.start, chunk.range.last))
+
+            chunk_image_paths = self.image_paths
+
+            if not os.path.exists(chunk.node.output.value):
+                os.mkdir(chunk.node.output.value)
+
+            gpus_to_use = [torch.cuda.current_device()]
+            video_predictor = build_sam3_video_predictor(checkpoint_path=chunk.node.segmentationModelPath.evalValue, gpus_to_use=gpus_to_use)
+
+            metadata_deep_model = {}
+            metadata_deep_model["Meshroom:mrSegmentation:DeepModelName"] = "SegmentAnything"
+            metadata_deep_model["Meshroom:mrSegmentation:DeepModelVersion"] = "sam3-Video-Crop"
+
+            # bboxes.json decoding
+            json_path = os.path.join(chunk.node.bboxesFolder.value, "bboxes.json")
+            frame_w = chunk_image_paths[0][3]
+            frame_h = chunk_image_paths[0][4]
+            par = chunk_image_paths[0][5]
+            x2_ok = os.path.exists(chunk.node.inputx2.value)
+            x4_ok = os.path.exists(chunk.node.inputx4.value)
+            bboxes = bboxUtils.extract_tracking(json_path, frame_w, frame_h, x2_ok, x4_ok, par)
+
+            logger.info(f"bboxes.keys() = {bboxes.keys()}")
+
+            full_mask_images = {}
+            img, h_ori, w_ori, p_a_r, orientation = image.loadImage(str(chunk_image_paths[0][0]), True)
+            sourceInfo = {"h_ori": h_ori, "w_ori": w_ori, "PAR": p_a_r, "orientation": orientation}
+            for frameId, image_path in enumerate(chunk_image_paths):
+                full_mask_images[image_path[2]] = np.zeros_like(img)
+
+            for key, frame_chunks in bboxes.items():
+
+                textPrompt = key.split('_')[0]
+                obj_id = key.split('_')[1]
+                logger.info(f"key = {key} ; text prompt = {textPrompt} ; obj_id = {obj_id}")
+
+                for frame_chunk in frame_chunks:
+                    logger.info(frame_chunk)
+                    pil_images = []
+                    mask_images = []
+                    firstFrameId = frame_chunk.start_frame
+                    for frame_idx, box in sorted(frame_chunk.boxes.items()):
+                        x1, y1, x2, y2 = box
+                        box_w = x2 - x1
+                        box_h = y2 - y1
+
+                        if box_w == 252 and box_h == 252:
+                            img, h_ori, w_ori, p_a_r, orientation = image.loadImage(str(chunk_image_paths[frame_idx - firstFrameId][7]), True)
+                            imgBuf = oiio.ImageBuf(img)
+                            imgBuf = oiio.ImageBufAlgo.crop(imgBuf, roi=oiio.ROI(4*x1, 4*x2, 4*y1, 4*y2))
+                        elif box_w == 504 and box_h == 504:
+                            img, h_ori, w_ori, p_a_r, orientation = image.loadImage(str(chunk_image_paths[frame_idx - firstFrameId][6]), True)
+                            imgBuf = oiio.ImageBuf(img)
+                            imgBuf = oiio.ImageBufAlgo.crop(imgBuf, roi=oiio.ROI(2*x1, 2*x2, 2*y1, 2*y2))
+                        else:
+                            img, h_ori, w_ori, p_a_r, orientation = image.loadImage(str(chunk_image_paths[frame_idx - firstFrameId][0]), True)
+                            imgBuf = oiio.ImageBuf(img)
+                            imgBuf = oiio.ImageBufAlgo.crop(imgBuf, roi=oiio.ROI(x1, x2, y1, y2))
+
+                        img_crop = imgBuf.get_pixels(format=oiio.FLOAT)
+                        pil_images.append(Image.fromarray((255.0*img_crop).astype("uint8")))
+                        mask_images.append(np.zeros_like(img_crop))
+
+                    response = video_predictor.handle_request(
+                        request=dict(
+                            type="start_session",
+                            resource_path=pil_images,
+                            )
+                    )
+                    session_id = response["session_id"]
+
+                    video_predictor.handle_request(
+                        request=dict(
+                            type="add_prompt",
+                            session_id=session_id,
+                            frame_index=0,
+                            text=textPrompt,
+                        )
+                    )
+                    outputs_per_frame = sam3Utils.propagateInVideo(video_predictor, session_id) #, fIdx, max_frame_num_to_track, track_dir)
+                    outputs_per_frame_visu = sam3Utils.prepareMasksForVisualization(outputs_per_frame)
+
+                    for frame_idx, box in sorted(frame_chunk.boxes.items()):
+                        x1, y1, x2, y2 = box
+                        box_w = x2 - x1
+                        box_h = y2 - y1
+                        frameId = frame_idx - firstFrameId
+                        for key, maskBoxProb in outputs_per_frame_visu[frameId].items():
+                            mask = maskBoxProb["mask"]
+                            buf_in = oiio.ImageBuf(mask.astype('float32'))
+                            buf_out = oiio.ImageBufAlgo.resample(buf_in, roi=oiio.ROI(0, box_w, 0, box_h))
+                            mask = buf_out.get_pixels().reshape(box_h, box_w, 1)
+                            tgt = full_mask_images[frame_idx][y1:y2 ,x1:x2, :]
+                            bool_mask = mask.squeeze() > 0
+                            tgt[bool_mask] = [255, 255, 255]
+
+                    video_predictor.handle_request(request=dict(type="close_session", session_id=session_id))
+
+
+            for frameId, image_path in enumerate(chunk_image_paths):
+                if chunk.node.maskInvert.value:
+                    mask = (full_mask_images[image_path[2]][:,:,0:1] == 0).astype('float32')
+                else:
+                    mask = (full_mask_images[image_path[2]][:,:,0:1] > 0).astype('float32')
+                logger.info(f"frameId: {frameId} - {image_path[0]}")
+
+                if chunk.node.keepFilename.value:
+                    outputFileMask = os.path.join(chunk.node.output.value, Path(image_path[0]).stem + "." + chunk.node.extensionOut.value)
+                else:
+                    outputFileMask = os.path.join(chunk.node.output.value, str(image_path[1]) + "." + chunk.node.extensionOut.value)
+
+                optWrite = avimg.ImageWriteOptions()
+                optWrite.toColorSpace(avimg.EImageColorSpace_NO_CONVERSION)
+                if Path(outputFileMask).suffix.lower() == ".exr":
+                    optWrite.exrCompressionMethod(avimg.EImageExrCompression_stringToEnum("DWAA"))
+                    optWrite.exrCompressionLevel(300)
+
+                image.writeImage(outputFileMask, mask, sourceInfo["h_ori"], sourceInfo["w_ori"], sourceInfo["orientation"],
+                                 sourceInfo["PAR"], metadata_deep_model, optWrite)
+
+        finally:
+            torch.cuda.empty_cache()
+
+
+def get_image_paths_list(input_path, path_folder_x2 = "", path_folder_x4 = ""):
+    from pyalicevision import sfmData, camera
+    from pyalicevision import sfmDataIO
+    from pathlib import Path
+
+    image_paths = []
+
+    if Path(input_path).suffix.lower() in [".sfm", ".abc"]:
+        if Path(input_path).exists():
+            dataAV = sfmData.SfMData()
+            if sfmDataIO.load(dataAV, input_path, sfmDataIO.ALL):
+                views = dataAV.getViews()
+                for id, v in views.items():
+                    image_x1_path = Path(v.getImage().getImagePath())
+                    image_x1_name = image_x1_path.name
+                    image_x2_path = None
+                    if os.path.isfile(os.path.join(path_folder_x2, image_x1_name)):
+                        image_x2_path = os.path.join(path_folder_x2, image_x1_name)
+                    image_x4_path = None
+                    if os.path.isfile(os.path.join(path_folder_x4, image_x1_name)):
+                        image_x4_path = os.path.join(path_folder_x4, image_x1_name)
+                    intrinsic = dataAV.getIntrinsicSharedPtr(v.getIntrinsicId())
+                    pinhole = camera.Pinhole.cast(intrinsic)
+                    par = 1.0
+                    if pinhole is not None:
+                        par = pinhole.getPixelAspectRatio()
+                    image_paths.append((image_x1_path, str(id), v.getFrameId(), v.getImage().getWidth(),
+                                        v.getImage().getHeight(), par, image_x2_path, image_x4_path))
+
+            image_paths.sort(key=lambda x: x[0])
+    else:
+        raise ValueError(f"Input path '{input_path}' is not a valid path (folder or sfmData file).")
+    return image_paths

--- a/meshroom/imageSegmentation/VideoSegmentationSam3Boxes.py
+++ b/meshroom/imageSegmentation/VideoSegmentationSam3Boxes.py
@@ -275,6 +275,7 @@ def get_image_paths_list(input_path, path_folder_x2 = "", path_folder_x4 = ""):
             dataAV = sfmData.SfMData()
             if sfmDataIO.load(dataAV, input_path, sfmDataIO.ALL):
                 views = dataAV.getViews()
+                commonParams = None
                 for id, v in views.items():
                     image_x1_path = Path(v.getImage().getImagePath())
                     image_x1_name = image_x1_path.name
@@ -289,6 +290,10 @@ def get_image_paths_list(input_path, path_folder_x2 = "", path_folder_x4 = ""):
                     par = 1.0
                     if pinhole is not None:
                         par = pinhole.getPixelAspectRatio()
+                    if commonParams is None:
+                        commonParams = [v.getImage().getWidth(), v.getImage().getHeight(), par, image_x2_path is None, image_x4_path is None]
+                    if commonParams != [v.getImage().getWidth(), v.getImage().getHeight(), par, image_x2_path is None, image_x4_path is None]:
+                        raise ValueError("All images do not have same dimensions or one image is missing its upscaled version.")
                     image_paths.append((image_x1_path, str(id), v.getFrameId(), v.getImage().getWidth(),
                                         v.getImage().getHeight(), par, image_x2_path, image_x4_path))
 

--- a/meshroom/imageSegmentation/VideoSegmentationSam3Boxes.py
+++ b/meshroom/imageSegmentation/VideoSegmentationSam3Boxes.py
@@ -1,6 +1,5 @@
 __version__ = "1.0"
 
-from functools import total_ordering
 import os
 from pathlib import Path
 
@@ -113,7 +112,6 @@ bounding boxes contained in a json file.
     ]
 
     def preprocess(self, node):
-        import re
         input_path = node.input.value
         image_paths = get_image_paths_list(input_path, node.inputx2.value, node.inputx4.value)
         if len(image_paths) == 0:
@@ -173,17 +171,18 @@ bounding boxes contained in a json file.
 
             for key, frame_chunks in bboxes.items():
 
-                textPrompt = key.split('_')[0]
-                obj_id = key.split('_')[1]
+                if "_" in key:
+                    textPrompt, obj_id = key.rsplit('_', 1)
+                else:
+                    textPrompt, obj_id = key, ""
                 logger.info(f"key = {key} ; text prompt = {textPrompt} ; obj_id = {obj_id}")
 
                 for frame_chunk in frame_chunks:
                     logger.info(frame_chunk)
                     pil_images = []
-                    mask_images = []
                     firstFrameId = frame_chunk.start_frame
                     for frame_idx, box in sorted(frame_chunk.boxes.items()):
-                        x1, y1, x2, y2 = box
+                        x1, y1, x2, y2 = bboxUtils.box_to_display(box, sourceInfo["PAR"])
                         box_w = x2 - x1
                         box_h = y2 - y1
 
@@ -202,7 +201,6 @@ bounding boxes contained in a json file.
 
                         img_crop = imgBuf.get_pixels(format=oiio.FLOAT)
                         pil_images.append(Image.fromarray((255.0*img_crop).astype("uint8")))
-                        mask_images.append(np.zeros_like(img_crop))
 
                     response = video_predictor.handle_request(
                         request=dict(

--- a/meshroom/imageSegmentation/VideoSegmentationSam3Boxes.py
+++ b/meshroom/imageSegmentation/VideoSegmentationSam3Boxes.py
@@ -30,13 +30,13 @@ bounding boxes contained in a json file.
         desc.File(
             name="inputx2",
             label="Inputx2",
-            description="Folder containing source images upscale by 2.",
+            description="Folder containing source images upscaled by 2.",
             value="",
         ),
         desc.File(
             name="inputx4",
             label="Inputx4",
-            description="Folder containing source images upscale by 4.",
+            description="Folder containing source images upscaled by 4.",
             value="",
         ),
         desc.File(
@@ -299,5 +299,5 @@ def get_image_paths_list(input_path, path_folder_x2 = "", path_folder_x4 = ""):
 
             image_paths.sort(key=lambda x: x[0])
     else:
-        raise ValueError(f"Input path '{input_path}' is not a valid path (folder or sfmData file).")
+        raise ValueError(f"Input path '{input_path}' is not a valid sfmData file.")
     return image_paths

--- a/meshroom/imageSegmentation/VideoSegmentationSam3Boxes.py
+++ b/meshroom/imageSegmentation/VideoSegmentationSam3Boxes.py
@@ -145,7 +145,7 @@ bounding boxes contained in a json file.
             if not os.path.exists(chunk.node.output.value):
                 os.mkdir(chunk.node.output.value)
 
-            gpus_to_use = [torch.cuda.current_device()]
+            gpus_to_use = [torch.cuda.current_device()] if chunk.node.useGpu.value else None
             video_predictor = build_sam3_video_predictor(checkpoint_path=chunk.node.segmentationModelPath.evalValue, gpus_to_use=gpus_to_use)
 
             metadata_deep_model = {}

--- a/meshroom/imageSegmentation/VideoSegmentationSam3Boxes.py
+++ b/meshroom/imageSegmentation/VideoSegmentationSam3Boxes.py
@@ -161,7 +161,7 @@ bounding boxes contained in a json file.
             x4_ok = os.path.exists(chunk.node.inputx4.value)
             bboxes = bboxUtils.extract_tracking(json_path, frame_w, frame_h, x2_ok, x4_ok, par)
 
-            logger.info(f"bboxes.keys() = {bboxes.keys()}")
+            logger.debug(f"bboxes.keys() = {bboxes.keys()}")
 
             full_mask_images = {}
             img, h_ori, w_ori, p_a_r, orientation = image.loadImage(str(chunk_image_paths[0][0]), True)

--- a/meshroom/imageSegmentation/VideoSegmentationSam3Text.py
+++ b/meshroom/imageSegmentation/VideoSegmentationSam3Text.py
@@ -351,7 +351,7 @@ from a text prompt.
                             crypto_id_fwd = np.zeros((img.shape[0], img.shape[1]), dtype=np.float32)
                             crypto_cov_fwd = np.zeros((img.shape[0], img.shape[1]), dtype=np.float32)
                             manifest_fwd = {}
-                        boxes[textPrompt]["forward"][frameId] = {}
+                        boxes[textPrompt]["forward"][firstFrameId + frameId] = {}
                         for key, maskBoxProb in outputs_per_frame_visu[frameId].items():
                             mask = maskBoxProb["mask"]
                             mask_images[frameId][mask] = [255, 255, 255]
@@ -366,7 +366,7 @@ from a text prompt.
                                 crypto_cov_fwd[mask] = 1.0
 
                             bbox = sam3Utils.xywhNorm2xyxy(maskBoxProb["box_xywh"], sourceInfo["w_ori"], sourceInfo["h_ori"]) # (x, y, x+w, y+h)
-                            boxes[textPrompt]["forward"][frameId][key] = bbox
+                            boxes[textPrompt]["forward"][firstFrameId + frameId][key] = bbox
 
                         if chunk.node.outputColorMasks.value:
                             if chunk.node.keepFilename.value:
@@ -398,7 +398,7 @@ from a text prompt.
                                 crypto_id_bwd = np.zeros((img.shape[0], img.shape[1]), dtype=np.float32)
                                 crypto_cov_bwd = np.zeros((img.shape[0], img.shape[1]), dtype=np.float32)
                                 manifest_bwd = {}
-                            boxes[textPrompt]["backward"][frameId] = {}
+                            boxes[textPrompt]["backward"][firstFrameId + frameId] = {}
                             for key, maskBoxProb in outputs_per_frame_visu[frameId].items():
                                 mask = maskBoxProb["mask"]
                                 mask_images[frameId][mask] = [255, 255, 255]
@@ -411,7 +411,7 @@ from a text prompt.
                                     crypto_id_bwd[mask] = f32_hash
                                     crypto_cov_bwd[mask] = 1.0
                                 bbox = sam3Utils.xywhNorm2xyxy(maskBoxProb["box_xywh"], sourceInfo["w_ori"], sourceInfo["h_ori"]) # (x, y, x+w, y+h)
-                                boxes[textPrompt]["backward"][frameId][key] = bbox
+                                boxes[textPrompt]["backward"][firstFrameId + frameId][key] = bbox
 
                             if chunk.node.outputColorMasks.value:
                                 if chunk.node.keepFilename.value:

--- a/meshroom/imageSegmentation/VideoSegmentationSam3Text.py
+++ b/meshroom/imageSegmentation/VideoSegmentationSam3Text.py
@@ -201,7 +201,7 @@ from a text prompt.
             if not os.path.exists(chunk.node.output.value):
                 os.mkdir(chunk.node.output.value)
 
-            gpus_to_use = [torch.cuda.current_device()] if chunk.node.useGPU.value else None
+            gpus_to_use = [torch.cuda.current_device()] if chunk.node.useGpu.value else None
             video_predictor = build_sam3_video_predictor(checkpoint_path=chunk.node.segmentationModelPath.evalValue, gpus_to_use=gpus_to_use)
 
             metadata_deep_model = {}

--- a/meshroom/imageSegmentation/VideoSegmentationSam3Text.py
+++ b/meshroom/imageSegmentation/VideoSegmentationSam3Text.py
@@ -302,7 +302,7 @@ from a text prompt.
                         sam3Utils.displayAt(outputs_per_frame_fwd, frameIdxToTextPrompt[n - 1], fIdx, sourceInfo["w_ori"], sourceInfo["h_ori"], logger)
 
                         mapping_fwd = sam3Utils.mapIds(outputs_per_frame[fIdx][fIdx], outputs_per_frame_fwd[frameIdxToTextPrompt[n - 1]][fIdx],
-                                                       sourceInfo["w_ori"], sourceInfo["h_ori"], logger)
+                                                       logger)
 
                         logger.debug(f"mapping fwd at key frame {fIdx}:\n{mapping_fwd}")
 
@@ -323,7 +323,7 @@ from a text prompt.
 
                             mapping_bwd = sam3Utils.mapIds(outputs_per_frame[fIdx][frameIdxToTextPrompt[n - 1]],
                                                            outputs_per_frame_bwd[frameIdxToTextPrompt[n - 1]][frameIdxToTextPrompt[n - 1]],
-                                                           sourceInfo["w_ori"], sourceInfo["h_ori"], logger)
+                                                           logger)
 
                             logger.debug(f"mapping bwd at key frame {frameIdxToTextPrompt[n - 1]}:\n{mapping_bwd}")
 

--- a/meshroom/imageSegmentation/VideoSegmentationSam3Text.py
+++ b/meshroom/imageSegmentation/VideoSegmentationSam3Text.py
@@ -201,7 +201,7 @@ from a text prompt.
             if not os.path.exists(chunk.node.output.value):
                 os.mkdir(chunk.node.output.value)
 
-            gpus_to_use = [torch.cuda.current_device()]
+            gpus_to_use = [torch.cuda.current_device()] if chunk.node.useGPU.value else None
             video_predictor = build_sam3_video_predictor(checkpoint_path=chunk.node.segmentationModelPath.evalValue, gpus_to_use=gpus_to_use)
 
             metadata_deep_model = {}

--- a/meshroom/imageSegmentation/VideoSegmentationSam3Text.py
+++ b/meshroom/imageSegmentation/VideoSegmentationSam3Text.py
@@ -340,7 +340,7 @@ from a text prompt.
                     logger.debug(f"Keys: {outputs_per_frame_fwd[fIdx].keys()}")
 
                     # write Fwd from fIdx to frameIdxToTextPrompt[n + 1]
-                    lastFIdxFwd = frameIdxToTextPrompt[n + 1] if n < len(frameIdxToTextPrompt) - 1 else fIdx + 1
+                    lastFIdxFwd = frameIdxToTextPrompt[n + 1] if n < len(frameIdxToTextPrompt) - 1 else frameNumber
                     outputs_per_frame_visu = sam3Utils.prepareMasksForVisualization(outputs_per_frame_fwd[fIdx])
 
                     logger.debug(f"Extract boxes for frame Fwd from : {fIdx} to {lastFIdxFwd - 1}")

--- a/meshroom/imageSegmentation/VideoSegmentationSam3Text.py
+++ b/meshroom/imageSegmentation/VideoSegmentationSam3Text.py
@@ -354,7 +354,7 @@ from a text prompt.
                         boxes[textPrompt]["forward"][firstFrameId + frameId] = {}
                         for key, maskBoxProb in outputs_per_frame_visu[frameId].items():
                             mask = maskBoxProb["mask"]
-                            mask_images[frameId][mask] = [255, 255, 255]
+                            mask_images[frameId][mask] = [(int(key) + 1) * 255, 255, 255]
                             color = colorPalette.at(int(key)) if colorPalette.at(int(key)) is not None else [255, 255, 255]
                             colorMaskImageFwd[mask] = [x/255.0 for x in color]
 
@@ -401,7 +401,7 @@ from a text prompt.
                             boxes[textPrompt]["backward"][firstFrameId + frameId] = {}
                             for key, maskBoxProb in outputs_per_frame_visu[frameId].items():
                                 mask = maskBoxProb["mask"]
-                                mask_images[frameId][mask] = [255, 255, 255]
+                                mask_images[frameId][mask] = [(int(key) + 1) * 255, 255, 255]
                                 color = colorPalette.at(int(key)) if colorPalette.at(int(key)) is not None else [255, 255, 255]
                                 colorMaskImageBwd[mask] = [x/255.0 for x in color]
                                 if chunk.node.outputCryptomatte.value:

--- a/segmentationRDS/bboxUtils.py
+++ b/segmentationRDS/bboxUtils.py
@@ -1,7 +1,7 @@
 import json
 from dataclasses import dataclass, field
 
-THRESHOLDS = [252, 504, 1008]
+SIZE_THRESHOLDS = [252, 504, 1008]
 
 @dataclass
 class TrackChunk:
@@ -93,7 +93,7 @@ def get_target_size(boxes: dict, par: float):
         h = y2 - y1
         max_size = max(max_size, w, h)
 
-    for threshold in THRESHOLDS:
+    for threshold in SIZE_THRESHOLDS :
         if max_size < threshold:
             return threshold
 
@@ -244,10 +244,10 @@ def extract_tracking(
             expanded_boxes = {}
             for frame_idx, box in raw_boxes.items():
                 if target_size is not None:
-                    if target_size < 504 and not x4_ok:
-                        target_size = 504
-                    if target_size < 1008 and not x2_ok:
-                        target_size = 1008
+                    if target_size < SIZE_THRESHOLDS[1] and not x4_ok:
+                        target_size = SIZE_THRESHOLDS[1]
+                    if target_size < SIZE_THRESHOLDS[2] and not x2_ok:
+                        target_size = SIZE_THRESHOLDS[2]
                     expanded = expand_box(box, target_size, par, frame_w, frame_h)
                     expanded_boxes[frame_idx] = expanded
                 else:

--- a/segmentationRDS/bboxUtils.py
+++ b/segmentationRDS/bboxUtils.py
@@ -63,7 +63,7 @@ def compute_iou(box1: list, box2: list) -> float:
 
 def merge_boxes(box1: list, box2: list, iou_threshold: float = 0.5) -> tuple[list, str]:
     """
-    Merge 2 boxes xyxy by taking the bounding boxe, if their IoU is higher than the threshold. 
+    Merge 2 boxes xyxy by taking the bounding box, if their IoU is higher than the threshold. 
     Else return the first box.
     """
     iou = compute_iou(box1, box2)
@@ -77,7 +77,7 @@ def merge_boxes(box1: list, box2: list, iou_threshold: float = 0.5) -> tuple[lis
         ]
         return merged, f"bounding (IoU={iou:.2f})"
     else:
-        return box1, f"forward     (IoU={iou:.2f} < seuil={iou_threshold})"
+        return box1, f"forward     (IoU={iou:.2f} < threshold={iou_threshold})"
 
 
 def get_target_size(boxes: dict, par: float):
@@ -138,7 +138,7 @@ def expand_box(box: list, target_size: int, par: float, frame_w: int, frame_h: i
 
     expanded_display = [int(new_x1), int(new_y1), int(new_x2), int(new_y2)]
 
-    # 3. Back conversion to source space
+    # Back conversion to source space
     return box_to_source(expanded_display, par)
 
 
@@ -184,7 +184,7 @@ def extract_tracking(
 ) -> dict:
     """
     Extract bounding boxes per object and organize them in chunck of consecutive frames.
-    Coordinates in the json file are supposed to be in the original source space, with the pixel aspect ratio not applicated.
+    Coordinates in the json file are supposed to be in the original source space, with the pixel aspect ratio not applied.
     The pixel aspect ratio is applied by reducing the raw number to deliver coordinates in the display space.
     When possible, all delivered bounding boxes for a given object are sized as 252x252, 504x504 or 1008x1008,
     to match with sam3 optimal model input.

--- a/segmentationRDS/bboxUtils.py
+++ b/segmentationRDS/bboxUtils.py
@@ -209,6 +209,8 @@ def extract_tracking(
         all_object_ids = set()
         for frame_data in forward.values():
             all_object_ids.update(frame_data.keys())
+        for frame_data in backward.values():
+            all_object_ids.update(frame_data.keys())
 
         for obj_id in sorted(all_object_ids, key=int):
             key = f"{label}_{obj_id}"

--- a/segmentationRDS/bboxUtils.py
+++ b/segmentationRDS/bboxUtils.py
@@ -1,0 +1,261 @@
+import json
+from dataclasses import dataclass, field
+
+THRESHOLDS = [252, 504, 1008]
+
+@dataclass
+class TrackChunk:
+    """A chunk of consecutive frames with their boxes."""
+    start_frame : int
+    end_frame   : int
+    boxes       : dict = field(default_factory=dict)  # {frame_idx: [x1, y1, x2, y2]}
+
+    def __repr__(self):
+        return f"TrackChunk(frames={self.start_frame}-{self.end_frame}, n={len(self.boxes)})"
+
+
+def compute_par_dimensions(frame_w: int, frame_h: int, par: float) -> tuple[int, int]:
+    """
+    image_display_w = frame_w
+    image_display_h = frame_h / par
+    """
+    display_w = frame_w
+    display_h = int(round(frame_h / par))
+    return display_w, display_h
+
+
+def box_to_display(box: list, par: float) -> list:
+    x1, y1, x2, y2 = box
+    return [
+        x1,
+        int(round(y1 / par)),
+        x2,
+        int(round(y2 / par)),
+    ]
+
+
+def box_to_source(box: list, par: float) -> list:
+    x1, y1, x2, y2 = box
+    return [
+        x1,
+        int(round(y1 * par)),
+        x2,
+        int(round(y2 * par)),
+    ]
+
+
+def compute_iou(box1: list, box2: list) -> float:
+    x1 = max(box1[0], box2[0])
+    y1 = max(box1[1], box2[1])
+    x2 = min(box1[2], box2[2])
+    y2 = min(box1[3], box2[3])
+
+    intersection = max(0, x2 - x1) * max(0, y2 - y1)
+    if intersection == 0:
+        return 0.0
+
+    area1 = (box1[2] - box1[0]) * (box1[3] - box1[1])
+    area2 = (box2[2] - box2[0]) * (box2[3] - box2[1])
+    union = area1 + area2 - intersection
+
+    return intersection / union if union > 0 else 0.0
+
+
+def merge_boxes(box1: list, box2: list, iou_threshold: float = 0.5) -> tuple[list, str]:
+    """
+    Merge 2 boxes xyxy by taking the bounding boxe, if their IoU is higher than the threshold. 
+    Else return the first box.
+    """
+    iou = compute_iou(box1, box2)
+
+    if iou >= iou_threshold:
+        merged = [
+            min(box1[0], box2[0]),
+            min(box1[1], box2[1]),
+            max(box1[2], box2[2]),
+            max(box1[3], box2[3]),
+        ]
+        return merged, f"bounding (IoU={iou:.2f})"
+    else:
+        return box1, f"forward     (IoU={iou:.2f} < seuil={iou_threshold})"
+
+
+def get_target_size(boxes: dict, par: float):
+    """
+    Compute the target size for a set of boxes.
+    Comparisons occur in the display space (with pixel aspect ratio applied)).
+    """
+    max_size = 0
+    for box in boxes.values():
+        display_box = box_to_display(box, par)
+        x1, y1, x2, y2 = display_box
+        w = x2 - x1
+        h = y2 - y1
+        max_size = max(max_size, w, h)
+
+    for threshold in THRESHOLDS:
+        if max_size < threshold:
+            return threshold
+
+    return max_size
+
+
+def expand_box(box: list, target_size: int, par: float, frame_w: int, frame_h: int) -> list:
+    """
+    Expand a box at target_size x target_size in display space,
+    and convert back in source space.
+    """
+    display_w, display_h = compute_par_dimensions(frame_w, frame_h, par)
+
+    # Conversion to display space
+    display_box = box_to_display(box, par)
+    x1, y1, x2, y2 = display_box
+
+    cx = (x1 + x2) / 2
+    cy = (y1 + y2) / 2
+
+    # Centered expansion in display space
+    new_x1 = cx - target_size / 2
+    new_y1 = cy - target_size / 2
+    new_x2 = cx + target_size / 2
+    new_y2 = cy + target_size / 2
+
+    # Horizontal adjust
+    if new_x1 < 0:
+        new_x2 = min(new_x2 - new_x1, display_w)
+        new_x1 = 0
+    elif new_x2 > display_w:
+        new_x1 = max(new_x1 - (new_x2 - display_w), 0)
+        new_x2 = display_w
+
+    # Vertical adjust
+    if new_y1 < 0:
+        new_y2 = min(new_y2 - new_y1, display_h)
+        new_y1 = 0
+    elif new_y2 > display_h:
+        new_y1 = max(new_y1 - (new_y2 - display_h), 0)
+        new_y2 = display_h
+
+    expanded_display = [int(new_x1), int(new_y1), int(new_x2), int(new_y2)]
+
+    # 3. Back conversion to source space
+    return box_to_source(expanded_display, par)
+
+
+def split_into_chunks(boxes: dict) -> list[TrackChunk]:
+    """
+    Split dictionnary {frame_idx: box} in chunks of consecutive frames.
+    """
+    if not boxes:
+        return []
+
+    sorted_frames = sorted(boxes.keys())
+    chunks = []
+    chunk_boxes = {sorted_frames[0]: boxes[sorted_frames[0]]}
+
+    for prev_frame, curr_frame in zip(sorted_frames, sorted_frames[1:]):
+        if curr_frame == prev_frame + 1:
+            chunk_boxes[curr_frame] = boxes[curr_frame]
+        else:
+            chunks.append(TrackChunk(
+                start_frame = min(chunk_boxes.keys()),
+                end_frame   = max(chunk_boxes.keys()),
+                boxes       = chunk_boxes
+            ))
+            chunk_boxes = {curr_frame: boxes[curr_frame]}
+
+    chunks.append(TrackChunk(
+        start_frame = min(chunk_boxes.keys()),
+        end_frame   = max(chunk_boxes.keys()),
+        boxes       = chunk_boxes
+    ))
+
+    return chunks
+
+
+def extract_tracking(
+    json_path     : str,
+    frame_w       : int,
+    frame_h       : int,
+    x2_ok         : bool = True,
+    x4_ok         : bool = True,
+    par           : float = 1.0,
+    iou_threshold : float = 0.5
+) -> dict:
+    """
+    Extract bounding boxes per object and organize them in chunck of consecutive frames.
+    Coordinates in the json file are supposed to be in the original source space, with the pixel aspect ratio not applicated.
+    The pixel aspect ratio is applied by reducing the raw number to deliver coordinates in the display space.
+    When possible, all delivered bounding boxes for a given object are sized as 252x252, 504x504 or 1008x1008,
+    to match with sam3 optimal model input.
+    Return a dictionnary :
+    {
+        "object_0_0": [TrackChunk(frames=0-10), TrackChunk(frames=15-20), ...],
+        "object_0_1": [TrackChunk(frames=0-20)],
+        ...
+        "object_1_0": [TrackChunk(frames=0-5), TrackChunk(frames=6-10), ...],
+        ...
+    }
+    """
+    with open(json_path, "r") as f:
+        data = json.load(f)
+
+    result = {}
+
+    for label, directions in data.items():
+        forward  = directions.get("forward",  {})
+        backward = directions.get("backward", {})
+
+        all_object_ids = set()
+        for frame_data in forward.values():
+            all_object_ids.update(frame_data.keys())
+
+        for obj_id in sorted(all_object_ids, key=int):
+            key = f"{label}_{obj_id}"
+            raw_boxes = {}
+
+            all_frames = sorted(
+                set(forward.keys()) | set(backward.keys()),
+                key=int
+            )
+
+            # Merge forward/backward (in source space) ---
+            for frame_idx in all_frames:
+                fwd_box = forward.get(frame_idx,  {}).get(obj_id)
+                bwd_box = backward.get(frame_idx, {}).get(obj_id)
+
+                if fwd_box and bwd_box:
+                    box, _ = merge_boxes(fwd_box, bwd_box, iou_threshold)
+                elif fwd_box:
+                    box = fwd_box
+                elif bwd_box:
+                    box = bwd_box
+                else:
+                    continue
+
+                raw_boxes[int(frame_idx)] = box
+
+            # --- compute target size ---
+            target_size = get_target_size(raw_boxes, par)
+
+            # --- Expand boxes in display space ---
+            expanded_boxes = {}
+            for frame_idx, box in raw_boxes.items():
+                if target_size is not None:
+                    if target_size < 504 and not x4_ok:
+                        target_size = 504
+                    if target_size < 1008 and not x2_ok:
+                        target_size = 1008
+                    expanded = expand_box(box, target_size, par, frame_w, frame_h)
+                    expanded_boxes[frame_idx] = expanded
+                else:
+                    expanded_boxes[frame_idx] = box
+
+            # --- Split in chunks ---
+            chunks = split_into_chunks(expanded_boxes)
+
+            result[key] = chunks
+
+    return result
+
+

--- a/segmentationRDS/sam3Utils.py
+++ b/segmentationRDS/sam3Utils.py
@@ -86,6 +86,10 @@ def mapIds(outputs_per_frame_detected, outputs_per_frame_propagated, logger):
     masksRef = outputs_per_frame_propagated["out_binary_masks"]
     boxesRef = outputs_per_frame_propagated["out_boxes_xywh"]
 
+    if len(ids) == 0 or len(masks) == 0 or len(idsRef) == 0 or len(masksRef) == 0:
+        logger.debug("mapIds: No detected or propagated objects; return empty mapping.")
+        return {}
+
     hs, ws = masks[0].shape
 
     logger.debug(f"{len(ids)}")

--- a/segmentationRDS/sam3Utils.py
+++ b/segmentationRDS/sam3Utils.py
@@ -76,7 +76,7 @@ def displayAt(outputs_per_frame, keyFrameIdx, frameId, imgWidth, imageHeight, lo
         prob = outputs_per_frame[keyFrameIdx][frameId]["out_probs"][i]
         logger.debug(f"{obj_ids}: {box} ; {prob}")
 
-def mapIds(outputs_per_frame_detected, outputs_per_frame_propagated, w, h, logger):
+def mapIds(outputs_per_frame_detected, outputs_per_frame_propagated, logger):
     import numpy as np
 
     ids = outputs_per_frame_detected["out_obj_ids"]
@@ -85,6 +85,8 @@ def mapIds(outputs_per_frame_detected, outputs_per_frame_propagated, w, h, logge
     idsRef = outputs_per_frame_propagated["out_obj_ids"]
     masksRef = outputs_per_frame_propagated["out_binary_masks"]
     boxesRef = outputs_per_frame_propagated["out_boxes_xywh"]
+
+    hs, ws = masks[0].shape
 
     logger.debug(f"{len(ids)}")
     logger.debug(f"{ids}")
@@ -101,10 +103,10 @@ def mapIds(outputs_per_frame_detected, outputs_per_frame_propagated, w, h, logge
             logger.debug(f"{id_det} vs {id_prop}: ios = {inter_over_smallest} ({ios_best})")
             if  inter_over_smallest > 0.9:
                 x1, y1, x2, y2 = box_inter
-                x1 = int(x1 * w)
-                y1 = int(y1 * h)
-                x2 = int(x2 * w)
-                y2 = int(y2 * h)
+                x1 = int(x1 * ws)
+                y1 = int(y1 * hs)
+                x2 = int(x2 * ws)
+                y2 = int(y2 * hs)
                 crop = masks[d][y1:y2, x1:x2]
                 cropRef = masksRef[p][y1:y2, x1:x2]
                 inter = np.logical_and(crop,cropRef).sum()


### PR DESCRIPTION
This pull request introduces a new segmentation node and makes several improvements and bug fixes to the video segmentation pipeline. The main addition is the new `VideoSegmentationSam3Boxes` node, which segments video frames using bounding boxes from a JSON file. Additionally, several changes in `VideoSegmentationSam3Text.py` improve the consistency of mask and bounding box handling.

**New Node Addition:**

* Added a new node `VideoSegmentationSam3Boxes` for segmenting video frames based on bounding boxes from a JSON file, supporting multiple input resolutions, GPU usage, mask inversion, and flexible output options. This node integrates with the SAM3 video predictor and handles mask generation, file management, and metadata.

**Improvements in VideoSegmentationSam3Text:**

* Fixed mapping and indexing for mask and bounding box dictionaries to use absolute frame IDs instead of local indices, ensuring correct association across the video sequence.
* Updated mask assignment to encode object IDs in the mask values for better downstream processing and visualization.
* Simplified function signatures by removing unnecessary width and height arguments from calls to `sam3Utils.mapIds`, as this information is not needed.

These changes collectively improve the flexibility, correctness, and usability of the video segmentation pipeline, especially for workflows involving bounding box-based segmentation and multi-resolution inputs.