### PR TITLE
[meshroom] Add metadata about SAM 3 bounding boxes

### DIFF
--- a/meshroom/imageSegmentation/VideoSegmentationSam3Boxes.py
+++ b/meshroom/imageSegmentation/VideoSegmentationSam3Boxes.py
@@ -223,6 +223,10 @@ For each tracked object (identified by a text prompt and an object ID):
             x4_ok = os.path.exists(chunk.node.inputx4.value)
             roundCrop = chunk.node.roundCropSize.value
             bboxes = bboxUtils.extract_tracking(json_path, frame_w, frame_h, x2_ok, x4_ok, roundCrop, par)
+            bboxes_metadata = bboxUtils.extract_tracking(json_path, frame_w, frame_h, False, False, roundCrop, par)
+            metadata_boxes = {}
+            for frameId in range(len(chunk_image_paths)):
+                metadata_boxes[firstFrameId + frameId] = {}
 
             logger.debug(f"bboxes.keys() = {bboxes.keys()}")
 
@@ -321,6 +325,19 @@ For each tracked object (identified by a text prompt and an object ID):
 
                         video_predictor.handle_request(request=dict(type="close_session", session_id=session_id))
 
+            for key, frame_chunks in bboxes_metadata.items():
+                if "_" in key:
+                    textPrompt, obj_id = key.rsplit('_', 1)
+                else:
+                    textPrompt, obj_id = key, ""
+                for frame_chunk in frame_chunks:
+                    for frame_idx, box in sorted(frame_chunk.boxes.items()):
+                        if textPrompt not in metadata_boxes[frame_idx]:
+                            metadata_boxes[frame_idx][textPrompt] = {}
+                        x1, y1, x2, y2 = box
+                        bbox_str = str(x1)+";"+str(y1)+";"+str(x2)+";"+str(y2)
+                        metadata_boxes[frame_idx][textPrompt][textPrompt+"_"+str(obj_id)] = bbox_str
+
             for frameId, image_path in enumerate(chunk_image_paths):
                 if chunk.node.maskInvert.value:
                     mask = (full_mask_images[image_path[2]][:,:,0:1] == 0).astype('float32')
@@ -338,6 +355,10 @@ For each tracked object (identified by a text prompt and an object ID):
                 if Path(outputFileMask).suffix.lower() == ".exr":
                     optWrite.exrCompressionMethod(avimg.EImageExrCompression_stringToEnum("DWAA"))
                     optWrite.exrCompressionLevel(300)
+
+                for prompt, bboxes in metadata_boxes[firstFrameId + frameId].items():
+                    for k, box in metadata_boxes[firstFrameId + frameId][prompt].items():
+                            metadata_deep_model["Meshroom:mrSegmentation:"+k] = box
 
                 image.writeImage(outputFileMask, mask, sourceInfo["h_ori"], sourceInfo["w_ori"], sourceInfo["orientation"],
                                  sourceInfo["PAR"], metadata_deep_model, optWrite)

--- a/meshroom/imageSegmentation/VideoSegmentationSam3Boxes.py
+++ b/meshroom/imageSegmentation/VideoSegmentationSam3Boxes.py
@@ -356,12 +356,13 @@ For each tracked object (identified by a text prompt and an object ID):
                     optWrite.exrCompressionMethod(avimg.EImageExrCompression_stringToEnum("DWAA"))
                     optWrite.exrCompressionLevel(300)
 
+                frame_metadata_deep_model = dict(metadata_deep_model)
                 for prompt, bboxes in metadata_boxes[firstFrameId + frameId].items():
                     for k, box in metadata_boxes[firstFrameId + frameId][prompt].items():
-                            metadata_deep_model["Meshroom:mrSegmentation:"+k] = box
+                            frame_metadata_deep_model["Meshroom:mrSegmentation:"+k] = box
 
                 image.writeImage(outputFileMask, mask, sourceInfo["h_ori"], sourceInfo["w_ori"], sourceInfo["orientation"],
-                                 sourceInfo["PAR"], metadata_deep_model, optWrite)
+                                 sourceInfo["PAR"], frame_metadata_deep_model, optWrite)
 
         finally:
             torch.cuda.empty_cache()

--- a/meshroom/imageSegmentation/VideoSegmentationSam3Boxes.py
+++ b/meshroom/imageSegmentation/VideoSegmentationSam3Boxes.py
@@ -335,8 +335,8 @@ For each tracked object (identified by a text prompt and an object ID):
                         if textPrompt not in metadata_boxes[frame_idx]:
                             metadata_boxes[frame_idx][textPrompt] = {}
                         x1, y1, x2, y2 = box
-                        bbox_str = str(x1)+";"+str(y1)+";"+str(x2)+";"+str(y2)
-                        metadata_boxes[frame_idx][textPrompt][textPrompt+"_"+str(obj_id)] = bbox_str
+                        bbox_str = str(x1) + ";" + str(y1)+ ";" + str(x2)+ ";" + str(y2)
+                        metadata_boxes[frame_idx][textPrompt][textPrompt + "_" + str(obj_id)] = bbox_str
 
             for frameId, image_path in enumerate(chunk_image_paths):
                 if chunk.node.maskInvert.value:
@@ -359,7 +359,7 @@ For each tracked object (identified by a text prompt and an object ID):
                 frame_metadata_deep_model = dict(metadata_deep_model)
                 for prompt, bboxes in metadata_boxes[firstFrameId + frameId].items():
                     for k, box in metadata_boxes[firstFrameId + frameId][prompt].items():
-                            frame_metadata_deep_model["Meshroom:mrSegmentation:"+k] = box
+                            frame_metadata_deep_model["Meshroom:mrSegmentation:" + k] = box
 
                 image.writeImage(outputFileMask, mask, sourceInfo["h_ori"], sourceInfo["w_ori"], sourceInfo["orientation"],
                                  sourceInfo["PAR"], frame_metadata_deep_model, optWrite)

--- a/meshroom/imageSegmentation/VideoSegmentationSam3Text.py
+++ b/meshroom/imageSegmentation/VideoSegmentationSam3Text.py
@@ -464,12 +464,13 @@ from a text prompt.
                     optWrite.exrCompressionMethod(avimg.EImageExrCompression_stringToEnum("DWAA"))
                     optWrite.exrCompressionLevel(300)
 
+                frame_metadata_deep_model = dict(metadata_deep_model)
                 for prompt in self.textPrompts:
                     for direction in ["forward", "backward"]:
                         for k, box in metadata_boxes[frameId][prompt][direction].items():
-                            metadata_deep_model["Meshroom:mrSegmentation:"+k] = box
+                            frame_metadata_deep_model["Meshroom:mrSegmentation:"+k] = box
 
-                image.writeImage(outputFileMask, mask, sourceInfo["h_ori"], sourceInfo["w_ori"], sourceInfo["orientation"], sourceInfo["PAR"], metadata_deep_model, optWrite)
+                image.writeImage(outputFileMask, mask, sourceInfo["h_ori"], sourceInfo["w_ori"], sourceInfo["orientation"], sourceInfo["PAR"], frame_metadata_deep_model, optWrite)
 
             jsonFilename = chunk.node.output.value + "/bboxes.json"
             with open(jsonFilename, "w", encoding="utf_8") as f:

--- a/meshroom/imageSegmentation/VideoSegmentationSam3Text.py
+++ b/meshroom/imageSegmentation/VideoSegmentationSam3Text.py
@@ -262,7 +262,7 @@ from a text prompt.
                 cryptoName = "object" if textPrompt == "" else textPrompt
                 metadata_deep_model["Meshroom:mrSegmentation:Prompt"] = textPrompt
                 for frameId in range(frameNumber):
-                    metadata_boxes[frameId][textPrompt] = {"forward":{}, "backward":{}}
+                    metadata_boxes[frameId][textPrompt] = {"forward": {}, "backward": {}}
 
                 video_predictor.handle_request(request=dict(type="reset_session", session_id=session_id))
 
@@ -372,9 +372,9 @@ from a text prompt.
 
                             bbox = sam3Utils.xywhNorm2xyxy(maskBoxProb["box_xywh"], sourceInfo["w_ori"], sourceInfo["h_ori"]) # (x, y, x+w, y+h)
                             boxes[textPrompt]["forward"][firstFrameId + frameId][key] = bbox
-                            x1,y1,x2,y2 = bbox
-                            bbox_str = str(x1)+";"+str(y1)+";"+str(x2)+";"+str(y2)
-                            metadata_boxes[frameId][textPrompt]["forward"]["fwd_"+textPrompt+"_"+str(key)] = bbox_str
+                            x1, y1, x2, y2 = bbox
+                            bbox_str = str(x1) + ";" + str(y1) + ";" + str(x2) + ";" + str(y2)
+                            metadata_boxes[frameId][textPrompt]["forward"]["fwd_" + textPrompt + "_" + str(key)] = bbox_str
 
                         if chunk.node.outputColorMasks.value:
                             if chunk.node.keepFilename.value:
@@ -468,7 +468,7 @@ from a text prompt.
                 for prompt in self.textPrompts:
                     for direction in ["forward", "backward"]:
                         for k, box in metadata_boxes[frameId][prompt][direction].items():
-                            frame_metadata_deep_model["Meshroom:mrSegmentation:"+k] = box
+                            frame_metadata_deep_model["Meshroom:mrSegmentation:" + k] = box
 
                 image.writeImage(outputFileMask, mask, sourceInfo["h_ori"], sourceInfo["w_ori"], sourceInfo["orientation"], sourceInfo["PAR"], frame_metadata_deep_model, optWrite)
 

--- a/meshroom/imageSegmentation/VideoSegmentationSam3Text.py
+++ b/meshroom/imageSegmentation/VideoSegmentationSam3Text.py
@@ -251,6 +251,9 @@ from a text prompt.
             session_id = response["session_id"]
 
             boxes = {}
+            metadata_boxes = {}
+            for frameId in range(frameNumber):
+                metadata_boxes[frameId] = {}
 
             for textPrompt in self.textPrompts:
 
@@ -258,6 +261,8 @@ from a text prompt.
                 boxes[textPrompt] = {"forward": {}, "backward": {}}
                 cryptoName = "object" if textPrompt == "" else textPrompt
                 metadata_deep_model["Meshroom:mrSegmentation:Prompt"] = textPrompt
+                for frameId in range(frameNumber):
+                    metadata_boxes[frameId][textPrompt] = {"forward":{}, "backward":{}}
 
                 video_predictor.handle_request(request=dict(type="reset_session", session_id=session_id))
 
@@ -367,6 +372,9 @@ from a text prompt.
 
                             bbox = sam3Utils.xywhNorm2xyxy(maskBoxProb["box_xywh"], sourceInfo["w_ori"], sourceInfo["h_ori"]) # (x, y, x+w, y+h)
                             boxes[textPrompt]["forward"][firstFrameId + frameId][key] = bbox
+                            x1,y1,x2,y2 = bbox
+                            bbox_str = str(x1)+";"+str(y1)+";"+str(x2)+";"+str(y2)
+                            metadata_boxes[frameId][textPrompt]["forward"]["fwd_"+textPrompt+"_"+str(key)] = bbox_str
 
                         if chunk.node.outputColorMasks.value:
                             if chunk.node.keepFilename.value:
@@ -412,6 +420,9 @@ from a text prompt.
                                     crypto_cov_bwd[mask] = 1.0
                                 bbox = sam3Utils.xywhNorm2xyxy(maskBoxProb["box_xywh"], sourceInfo["w_ori"], sourceInfo["h_ori"]) # (x, y, x+w, y+h)
                                 boxes[textPrompt]["backward"][firstFrameId + frameId][key] = bbox
+                                x1,y1,x2,y2 = bbox
+                                bbox_str = str(x1)+";"+str(y1)+";"+str(x2)+";"+str(y2)
+                                metadata_boxes[frameId][textPrompt]["backward"]["bwd_"+textPrompt+"_"+str(key)] = bbox_str
 
                             if chunk.node.outputColorMasks.value:
                                 if chunk.node.keepFilename.value:
@@ -452,6 +463,11 @@ from a text prompt.
                 if Path(outputFileMask).suffix.lower() == ".exr":
                     optWrite.exrCompressionMethod(avimg.EImageExrCompression_stringToEnum("DWAA"))
                     optWrite.exrCompressionLevel(300)
+
+                for prompt in self.textPrompts:
+                    for direction in ["forward", "backward"]:
+                        for k, box in metadata_boxes[frameId][prompt][direction].items():
+                            metadata_deep_model["Meshroom:mrSegmentation:"+k] = box
 
                 image.writeImage(outputFileMask, mask, sourceInfo["h_ori"], sourceInfo["w_ori"], sourceInfo["orientation"], sourceInfo["PAR"], metadata_deep_model, optWrite)
 


### PR DESCRIPTION
This pull request enhances the way bounding box metadata is generated and stored during the image segmentation process in both `VideoSegmentationSam3Boxes.py` and `VideoSegmentationSam3Text.py`. The main improvement is the structured collection and embedding of bounding box information into image metadata, enabling better traceability and downstream usage of segmentation results.

**Bounding box metadata handling improvements:**

* Added creation and population of a `metadata_boxes` structure to store bounding box coordinates for each frame and prompt, formatted as strings, in both `VideoSegmentationSam3Boxes.py` and `VideoSegmentationSam3Text.py`.
* Iterated through all bounding boxes and inserted their string representations into the `metadata_boxes` dictionary, indexed by frame, prompt, and direction (forward/backward), in both scripts.

**Embedding metadata into output images:**

* At the time of writing the output mask image, iterated over all entries in `metadata_boxes` for the current frame and added them to the `metadata_deep_model` dictionary, ensuring that each bounding box is embedded as image metadata.

These changes standardize and automate the inclusion of segmentation bounding box metadata in outputs, facilitating improved interoperability and analysis in downstream tasks.