### PR TITLE
Rename preprocess method

### DIFF
--- a/meshroom/imageSegmentation/VideoSegmentationSam3Text.py
+++ b/meshroom/imageSegmentation/VideoSegmentationSam3Text.py
@@ -159,7 +159,7 @@ from a text prompt.
         ),
     ]
 
-    def preprocess(self, node):
+    def resolvePaths(self, node):
         import re
         input_path = node.input.value
         image_paths = get_image_paths_list(input_path)
@@ -186,6 +186,9 @@ from a text prompt.
         import json
 
         try:
+
+            self.resolvePaths(chunk.node)
+
             logger.setLevel(chunk.node.verboseLevel.value.upper())
 
             if not chunk.node.input:


### PR DESCRIPTION
This pull request refactors the `VideoSegmentationSam3Text` node in `meshroom/imageSegmentation/VideoSegmentationSam3Text.py` to improve code clarity and ensure path resolution occurs earlier in the processing pipeline. The most important changes are:

**Refactoring and Code Organization:**

* Renamed the `preprocess` method to `resolvePaths` in the `VideoSegmentationSam3Text` class for clearer intent and maintainability.

**Processing Logic Improvements:**

* Added a call to the new `resolvePaths` method at the beginning of the `processChunk` method to ensure input paths are resolved before processing each chunk.