### PR TITLE
[meshroom] Add videoMaMa node

### DIFF
--- a/meshroom/sam3/VideoSegmentationSam3Text.py
+++ b/meshroom/sam3/VideoSegmentationSam3Text.py
@@ -171,7 +171,7 @@ from a text prompt.
         self.textPrompts = re.split(r'[\n]+', node.prompt.value)
         self.textPrompts = [str(textPrompt) for textPrompt in self.textPrompts if textPrompt]
         srcFilename = "<FILESTEM>" if node.keepFilename.value else "<VIEW_ID>"
-        node.colorMasksFwd.value = node.output.value + "/colorMask_" + self.textPrompts[0] + "_fwd_" + srcFilename + ".png"
+        node.colorMasksFwd.value = node.output.value + "/colorMask_" + self.textPrompts[0] + "_fwd_" + srcFilename + ".exr"
         node.colorMasksBwd.value = node.output.value + "/colorMask_" + self.textPrompts[0] + "_bwd_" + srcFilename + ".png"
         node.cryptomatteFwd.value = node.output.value + "/cryptomatte_" + self.textPrompts[0] + "_fwd_" + srcFilename + ".png"
         node.cryptomatteBwd.value = node.output.value + "/cryptomatte_" + self.textPrompts[0] + "_bwd_" + srcFilename + ".png"
@@ -381,7 +381,7 @@ from a text prompt.
 
                         if chunk.node.outputColorMasks.value:
                             if chunk.node.keepFilename.value:
-                                outputFileColorMask = os.path.join(chunk.node.output.value, "colorMask_" + textPrompt + "_fwd_" + str(Path(chunk_image_paths[frameId][0]).stem) + ".png")
+                                outputFileColorMask = os.path.join(chunk.node.output.value, "colorMask_" + textPrompt + "_fwd_" + str(Path(chunk_image_paths[frameId][0]).stem) + ".exr")
                             else:
                                 outputFileColorMask = os.path.join(chunk.node.output.value, "colorMask_" + textPrompt + "_fwd_" + str(chunk_image_paths[frameId][1]) + ".png")
 

--- a/meshroom/videoMaMa/VideoMaMa.py
+++ b/meshroom/videoMaMa/VideoMaMa.py
@@ -123,6 +123,8 @@ class VideoMaMa(desc.Node):
         inputFileMask = None
         if not Path(pathIn).exists():
             raise FileNotFoundError(f"Input path '{pathIn}' does not exist.")
+        if not Path(pathMask).exists():
+            raise FileNotFoundError(f"Input path for masks '{pathMask}' does not exist.")
         if not Path(pathIn).suffix.lower() in [".sfm", ".abc"]:
             raise ValueError(f"Input path '{pathIn}' is not a valid sfmData file.")
         if not os.path.exists(os.path.join(pathMask,"bboxes.json")):
@@ -253,7 +255,9 @@ class VideoMaMa(desc.Node):
                 os.mkdir(chunk.node.output.value)
 
             device = torch.device("cuda") if torch.cuda.is_available() and chunk.node.useGpu.value else torch.device("cpu")
-            model_path = os.path.join(os.getenv("VIDEOMAMA_MODELS_PATH"), "fromSammieRoto")
+            model_path = os.getenv("VIDEOMAMA_SR_MODELS_PATH")
+            if not model_path:
+                raise EnvironmentError("VIDEOMAMA_SR_MODELS_PATH is not set; it must point to the folder containing the same VideoMaMa model files as the ones used in SammieRoto2.")
 
             try:
                 pipeline = videoMaMaUtils.VideoInferencePipeline(
@@ -324,9 +328,13 @@ class VideoMaMa(desc.Node):
                         stopFrameId = frame_chunk.start_frame + slice_end
                         logger.info(f"slice #{slice_idx}/{len(time_slices)-1}: processing frames [{startFrameId}, {stopFrameId}[")
                         if slice_idx > 0:
-                            cond_frames = cond_frames[-overlap:]
-                            mask_frames = mask_frames[-overlap:]
-                            startFrameId += overlap
+                            if overlap > 0:
+                                cond_frames = cond_frames[-overlap:]
+                                mask_frames = mask_frames[-overlap:]
+                                startFrameId += overlap
+                            else:
+                                cond_frames = []
+                                mask_frames = []
                         for frameId, box in frame_chunk.boxes.items():
                             if frameId >= startFrameId and frameId < stopFrameId:
                                 img, h_ori, w_ori, PAR, orientation = image.loadImage(str(chunk_image_paths[frameId - frame_chunk.start_frame][0]), True)
@@ -408,8 +416,8 @@ class VideoMaMa(desc.Node):
 
                 frame_metadata_deep_model = dict(metadata_deep_model_base)
                 for prompt, bboxes in metadata_boxes[firstFrameId + frameId].items():
-                    for k, box in metadata_boxes[firstFrameId + frameId][prompt].items():
-                            frame_metadata_deep_model["Meshroom:mrSegmentation:" + k] = box
+                    for k, box in bboxes.items():
+                        frame_metadata_deep_model["Meshroom:mrSegmentation:" + k] = box
                 alpha = full_alpha[image_path[2]]
                 image.writeImage(image_path[4], alpha, sourceInfo["h_ori"], sourceInfo["w_ori"], sourceInfo["orientation"],
                                 sourceInfo["PAR"], frame_metadata_deep_model, optWrite)

--- a/meshroom/videoMaMa/VideoMaMa.py
+++ b/meshroom/videoMaMa/VideoMaMa.py
@@ -1,7 +1,5 @@
 __version__ = "1.0"
 
-from distutils.log import error
-from functools import total_ordering
 import os
 from pathlib import Path
 
@@ -18,7 +16,6 @@ class VideoMaMa(desc.Node):
 """
     size = avpar.DynamicViewsSize("input")
     gpu = lambda node: desc.Level.EXTREME if node.inferenceSize.value == 2048 else desc.Level.INTENSIVE
-    _cuda_tag = "cuda24G"
 
     category = "Matting"
 
@@ -117,12 +114,6 @@ class VideoMaMa(desc.Node):
         ),
     ]
 
-    def onInferenceSizeChanged(self, node):
-        if node.inferenceSize.value < 2048:
-            _cuda_tag = "cuda24G"
-        else:
-            _cuda_tag = ""
-
     def _resolve_paths(self, pathIn, pathMask, extMask, outDir, keepFilename, extOut):
         from pyalicevision import sfmData, camera
         from pyalicevision import sfmDataIO
@@ -163,28 +154,45 @@ class VideoMaMa(desc.Node):
 
         return paths
 
+    def _padx8_image(self, image):
+        import numpy as np
+
+        h, w = image.shape[:2]
+        new_h = (h + 7) // 8 * 8
+        new_w = (w + 7) // 8 * 8
+        pad_h = new_h - h
+        pad_w = new_w - w
+        if pad_h == 0 and pad_w == 0:
+            return image
+        if image.ndim == 2:
+            return np.pad(image, ((0, pad_h), (0, pad_w)), mode='constant', constant_values=0)
+        else:
+            return np.pad(image, ((0, pad_h), (0, pad_w), (0, 0)), mode='constant', constant_values=0)
+
     def _resize_image(self, image, max_size):
-        """Resize image and ensure dimensions are multiples of 8 for the model."""
         import cv2
 
         h, w = image.shape[:2]
-        
         scale = 1.0
         if max_size > 0:
             max_side = max(h, w)
             if max_side > max_size:
                 scale = max_size / max_side
 
-        new_h = (int(h * scale) // 8) * 8
-        new_w = (int(w * scale) // 8) * 8
-        
-        return cv2.resize(image, (new_w, new_h), interpolation=cv2.INTER_AREA)
+        if scale < 1.0:
+            new_h = (int(h * scale) // 8) * 8
+            new_w = (int(w * scale) // 8) * 8
+            return "resize", cv2.resize(image, (new_w, new_h), interpolation=cv2.INTER_AREA)
 
-    def _restore_image_size(self, image, original_size):
-        """Restore image to original size. original_size must be (w, h) as expected by cv2."""
+        return "pad", self._padx8_image(image)
+
+    def _restore_image_size(self, image, original_size, method):
         import cv2
         original_w, original_h = original_size
-        restored_image = cv2.resize(image, (original_w, original_h), interpolation=cv2.INTER_LINEAR)
+        if method == "resize":
+            restored_image = cv2.resize(image, (original_w, original_h), interpolation=cv2.INTER_LINEAR)
+        else:
+            restored_image = image[0:original_h, 0:original_w, :]
         return restored_image
 
     def _generate_time_slices(self, total_frames, batch_size, overlap):
@@ -259,7 +267,7 @@ class VideoMaMa(desc.Node):
                     enable_vae_tiling=False,        # Tiling VAE is not worth it
                     enable_vae_slicing=True,        # Process VAE one image at a time
                 )
-                print(f"Loaded videoMaMa model to {device}") # with max size {max_size}, overlap={overlap}, batch={batch_size}, and combined={combined}")
+                logger.info(f"Loaded videoMaMa model to {device}")
             except Exception as e:
                 raise ValueError(f"Error loading VideoMaMa pipeline: {e}")
 
@@ -326,18 +334,21 @@ class VideoMaMa(desc.Node):
                                 imgBuf = oiio.ImageBuf(img)
                                 imgBuf = oiio.ImageBufAlgo.crop(imgBuf, roi=oiio.ROI(x1, x2, y1, y2))
                                 img_crop = imgBuf.get_pixels(format=oiio.FLOAT)
-                                frame = self._resize_image(img_crop, max(chunk.node.inferenceSize.value, 2160))
+                                method, frame = self._resize_image(img_crop, chunk.node.inferenceSize.value)
                                 resized_h, resized_w = frame.shape[:2]
                                 mask_path = str(chunk_image_paths[frameId - frame_chunk.start_frame][1])
                                 mask, h_ori_mask, w_ori_mask, PAR_mask, orientation_mask = image.loadImage(mask_path, True)
                                 imgBuf = oiio.ImageBuf(mask)
                                 imgBuf = oiio.ImageBufAlgo.crop(imgBuf, roi=oiio.ROI(x1, x2, y1, y2))
                                 img_crop = imgBuf.get_pixels(format=oiio.FLOAT)
-                                mask = cv2.resize(img_crop, (resized_w, resized_h), interpolation=cv2.INTER_NEAREST)
+                                if method == "resize":
+                                    mask = cv2.resize(img_crop, (resized_w, resized_h), interpolation=cv2.INTER_NEAREST)
+                                else:
+                                    mask = self._padx8_image(img_crop)
                                 cond_frames.append(frame)
                                 mask_frames.append(mask)
                         nb, sh = self._check_lists_compatibility(cond_frames, mask_frames)
-                        logger.info(f"slice_idx = {slice_idx} ; {nb} frames ; shape = {sh}")
+                        logger.info(f"slice_idx = {slice_idx} ; {nb} frames ; shape = {sh} ; method = {method}")
 
                         try:
                             with torch.amp.autocast('cuda', enabled=False):
@@ -355,7 +366,7 @@ class VideoMaMa(desc.Node):
                                 blended_frame = (1.0 - new_weight) * previous_frames[i] + new_weight * output_frames[i].copy()
                                 mix_frames.append(blended_frame)
 
-                        if len(output_frames) >= overlap: # and slice_idx < len(time_slices) - 1:
+                        if len(output_frames) >= overlap:
                             previous_frames = copy.deepcopy(output_frames[-overlap:])
 
                         if slice_idx > 0:
@@ -371,8 +382,8 @@ class VideoMaMa(desc.Node):
                                     box_w = x2 - x1
                                     box_h = y2 - y1
                                     output_frame = mix_frames[frame_idx] if frame_idx < overlap else output_frames[frame_idx].copy()
-                                    alpha = self._restore_image_size(output_frame, (box_w, box_h))
-                                    full_alpha[frameId][y1:y2, x1:x2, :] = alpha
+                                    alpha = self._restore_image_size(output_frame, (box_w, box_h), method)
+                                    full_alpha[frameId][y1:y2, x1:x2, :] = np.maximum(alpha, full_alpha[frameId][y1:y2, x1:x2, :])
 
             for key, frame_chunks in bboxes_metadata.items():
                 if "_" in key:

--- a/meshroom/videoMaMa/VideoMaMa.py
+++ b/meshroom/videoMaMa/VideoMaMa.py
@@ -225,6 +225,7 @@ class VideoMaMa(desc.Node):
         import torch
         from pyalicevision import image as avimg
         import OpenImageIO as oiio
+        import copy
 
         try:
             logger.setLevel(chunk.node.verboseLevel.value.upper())
@@ -311,8 +312,6 @@ class VideoMaMa(desc.Node):
                     cond_frames = []
                     mask_frames = []
                     for slice_idx, (slice_start, slice_end) in enumerate(time_slices):
-                        # startFrameId = firstFrameId + slice_start
-                        # stopFrameId = firstFrameId + slice_end
                         startFrameId = frame_chunk.start_frame + slice_start
                         stopFrameId = frame_chunk.start_frame + slice_end
                         logger.info(f"slice #{slice_idx}/{len(time_slices)-1}: processing frames [{startFrameId}, {stopFrameId}[")
@@ -322,7 +321,6 @@ class VideoMaMa(desc.Node):
                             startFrameId += overlap
                         for frameId, box in frame_chunk.boxes.items():
                             if frameId >= startFrameId and frameId < stopFrameId:
-                                #img, h_ori, w_ori, PAR, orientation = image.loadImage(str(chunk_image_paths[frameId - firstFrameId][0]), True)
                                 img, h_ori, w_ori, PAR, orientation = image.loadImage(str(chunk_image_paths[frameId - frame_chunk.start_frame][0]), True)
                                 x1, y1, x2, y2 = bboxUtils.box_to_display(box, sourceInfo["PAR"])
                                 imgBuf = oiio.ImageBuf(img)
@@ -330,7 +328,6 @@ class VideoMaMa(desc.Node):
                                 img_crop = imgBuf.get_pixels(format=oiio.FLOAT)
                                 frame = self._resize_image(img_crop, max(chunk.node.inferenceSize.value, 2160))
                                 resized_h, resized_w = frame.shape[:2]
-                                #mask_path = str(chunk_image_paths[frameId - firstFrameId][1])
                                 mask_path = str(chunk_image_paths[frameId - frame_chunk.start_frame][1])
                                 mask, h_ori_mask, w_ori_mask, PAR_mask, orientation_mask = image.loadImage(mask_path, True)
                                 imgBuf = oiio.ImageBuf(mask)
@@ -349,8 +346,6 @@ class VideoMaMa(desc.Node):
                             logger.error(f"Error in VideoMaMa inference at slice {slice_idx}: {ex}")
                             raise
 
-                        if len(output_frames) >= overlap and slice_idx < len(time_slices) - 1:
-                            previous_frames = output_frames[-overlap:].copy()
                         if slice_idx == 0:
                             mix_frames = output_frames[0:overlap]
                         else:
@@ -359,6 +354,9 @@ class VideoMaMa(desc.Node):
                                 new_weight = (i + 1) / (overlap + 1)
                                 blended_frame = (1.0 - new_weight) * previous_frames[i] + new_weight * output_frames[i].copy()
                                 mix_frames.append(blended_frame)
+
+                        if len(output_frames) >= overlap: # and slice_idx < len(time_slices) - 1:
+                            previous_frames = copy.deepcopy(output_frames[-overlap:])
 
                         if slice_idx > 0:
                             startFrameId -= overlap
@@ -372,7 +370,7 @@ class VideoMaMa(desc.Node):
                                     x1, y1, x2, y2 = bboxUtils.box_to_display(box, sourceInfo["PAR"])
                                     box_w = x2 - x1
                                     box_h = y2 - y1
-                                    output_frame = mix_frames[frame_idx].copy() if frame_idx < overlap else output_frames[frame_idx].copy()
+                                    output_frame = mix_frames[frame_idx] if frame_idx < overlap else output_frames[frame_idx].copy()
                                     alpha = self._restore_image_size(output_frame, (box_w, box_h))
                                     full_alpha[frameId][y1:y2, x1:x2, :] = alpha
 

--- a/meshroom/videoMaMa/VideoMaMa.py
+++ b/meshroom/videoMaMa/VideoMaMa.py
@@ -1,0 +1,409 @@
+__version__ = "1.0"
+
+from distutils.log import error
+from functools import total_ordering
+import os
+from pathlib import Path
+
+from meshroom.core import desc
+from meshroom.core.utils import VERBOSE_LEVEL
+from pyalicevision import parallelization as avpar
+
+import logging
+logger = logging.getLogger("VideoMaMa")
+
+class VideoMaMa(desc.Node):
+    """
+## Matting with VideoMaMa
+"""
+    size = avpar.DynamicViewsSize("input")
+    gpu = lambda node: desc.Level.EXTREME if node.inferenceSize.value == 2048 else desc.Level.INTENSIVE
+    _cuda_tag = "cuda24G"
+
+    category = "Matting"
+
+    inputs = [
+        desc.File(
+            name="input",
+            label="Input",
+            description="SfMData file.",
+            value="",
+        ),
+        desc.File(
+            name="inputMask",
+            label="Mask Folder",
+            description="Folder containing the masks used as prompt.",
+            value="",
+        ),
+        desc.ChoiceParam(
+            name="extensionMask",
+            label="Mask File Extension",
+            description="Input mask file extension.",
+            value="exr",
+            values=["exr", "png", "jpg"],
+            exclusive=True,
+        ),
+        desc.ChoiceParam(
+            name="inferenceSize",
+            label="Inference Size Max",
+            description="Maximum size of the largest image dimension for inference. Automatic resize if higher.",
+            value=1024,
+            values=[512, 640, 768, 896, 1024, 1576, 2048],
+            exclusive=True,
+        ),
+        desc.IntParam(
+            name="batchSize",
+            label="Batch Size",
+            description="Number of frames process simultaneously.",
+            value=16,
+        ),
+        desc.IntParam(
+            name="overlap",
+            label="Overlap",
+            description="Number of overlaping frames between 2 consecutive batches. Must be lower than batch size.",
+            value=2,
+        ),
+        desc.FloatParam(
+            name="boxExtensionFactor",
+            label="Bounding Box Extension Factor",
+            description="Extension factor of bounding boxes containing binary masks.",
+            value=1.1,
+        ),
+        desc.BoolParam(
+            name="useGpu",
+            label="Use GPU",
+            description="Use GPU for computation if available.",
+            value=True,
+            invalidate=False,
+        ),
+        desc.BoolParam(
+            name="keepFilename",
+            label="Keep Filename",
+            description="Keep the filename of the inputs for the outputs.",
+            value=True,
+        ),
+        desc.ChoiceParam(
+            name="extensionOut",
+            label="Output File Extension",
+            description="Output image file extension.\n"
+                        "If unset, the output file extension will match the input's if possible.",
+            value="exr",
+            values=["exr", "png", "jpg"],
+            exclusive=True,
+        ),
+        desc.ChoiceParam(
+            name="verboseLevel",
+            label="Verbose Level",
+            description="Verbosity level (fatal, error, warning, info, debug).",
+            value="info",
+            values=VERBOSE_LEVEL,
+            exclusive=True,
+        ),
+    ]
+
+    outputs = [
+        desc.File(
+            name="output",
+            label="Mattes Folder",
+            description="Output path for the mattes.",
+            value="{nodeCacheFolder}",
+        ),
+        desc.File(
+            name="matte",
+            label="Matte",
+            description="Generated mattes.",
+            semantic="image",
+            value=lambda attr: "{nodeCacheFolder}/" + ("<FILESTEM>" if attr.node.keepFilename.value else "<VIEW_ID>") + "." + attr.node.extensionOut.value,
+        ),
+    ]
+
+    def onInferenceSizeChanged(self, node):
+        if node.inferenceSize.value < 2048:
+            _cuda_tag = "cuda24G"
+        else:
+            _cuda_tag = ""
+
+    def _resolve_paths(self, pathIn, pathMask, extMask, outDir, keepFilename, extOut):
+        from pyalicevision import sfmData, camera
+        from pyalicevision import sfmDataIO
+        from pathlib import Path
+
+        paths = []
+        inputFileMask = None
+        if not Path(pathIn).exists():
+            raise FileNotFoundError(f"Input path '{pathIn}' does not exist.")
+        if not Path(pathIn).suffix.lower() in [".sfm", ".abc"]:
+            raise ValueError(f"Input path '{pathIn}' is not a valid sfmData file.")
+        if not os.path.exists(os.path.join(pathMask,"bboxes.json")):
+            raise FileNotFoundError(f'No file containing bounding boxes')
+        
+        dataAV = sfmData.SfMData()
+        if sfmDataIO.load(dataAV, pathIn, sfmDataIO.ALL) and os.path.isdir(outDir):
+            views = dataAV.getViews()
+            for id, v in views.items():
+                inputFile = v.getImage().getImagePath()
+                frameId = v.getFrameId()
+                imgWidth = v.getImage().getWidth()
+                imgHeight = v.getImage().getHeight()
+                intrinsic = dataAV.getIntrinsicSharedPtr(v.getIntrinsicId())
+                pinhole = camera.Pinhole.cast(intrinsic)
+                par = 1.0
+                if pinhole is not None:
+                    par = pinhole.getPixelAspectRatio()
+                if keepFilename:
+                    if pathMask:
+                        inputFileMask = os.path.join(pathMask, Path(inputFile).stem + "." + extMask)
+                    outputFileMatte = os.path.join(outDir, Path(inputFile).stem + "." + extOut)
+                else:
+                    if pathMask:
+                        inputFileMask = os.path.join(pathMask, str(id) + "." + extMask)
+                    outputFileMatte = os.path.join(outDir, str(id) + "." + extOut)
+                paths.append((inputFile, inputFileMask, frameId, str(id), outputFileMatte, imgWidth, imgHeight, par))
+            paths.sort(key=lambda x: x[0])
+
+        return paths
+
+    def _resize_image(self, image, max_size):
+        """Resize image and ensure dimensions are multiples of 8 for the model."""
+        import cv2
+
+        h, w = image.shape[:2]
+        
+        scale = 1.0
+        if max_size > 0:
+            max_side = max(h, w)
+            if max_side > max_size:
+                scale = max_size / max_side
+
+        new_h = (int(h * scale) // 8) * 8
+        new_w = (int(w * scale) // 8) * 8
+        
+        return cv2.resize(image, (new_w, new_h), interpolation=cv2.INTER_AREA)
+
+    def _restore_image_size(self, image, original_size):
+        """Restore image to original size. original_size must be (w, h) as expected by cv2."""
+        import cv2
+        original_w, original_h = original_size
+        restored_image = cv2.resize(image, (original_w, original_h), interpolation=cv2.INTER_LINEAR)
+        return restored_image
+
+    def _generate_time_slices(self, total_frames, batch_size, overlap):
+        step = batch_size - overlap
+        if step <= 0:
+            overlap = batch_size - 1
+            step = 1
+
+        if total_frames <= batch_size:
+            return [(0, total_frames)]
+
+        time_slices = []
+        pos = 0
+        while pos < total_frames:
+            end = min(pos + batch_size, total_frames)
+            time_slices.append((pos, end))
+            if end >= total_frames:
+                break
+            pos += step
+
+        return time_slices
+
+    def _check_lists_compatibility(self, list1, list2):
+        if len(list1) != len(list2):
+            raise ValueError("Lists have different size.")
+        if len(list1) == 0:
+            return 0, None
+        for (arr1, arr2) in zip(list1, list2):
+            if arr1.shape != arr2.shape:
+                raise ValueError("List content don't match.")
+        return len(list1), list1[0].shape
+
+    def processChunk(self, chunk):
+        from segmentationRDS import image, bboxUtils, videoMaMaUtils
+
+        import cv2
+        import numpy as np
+        import torch
+        from pyalicevision import image as avimg
+        import OpenImageIO as oiio
+
+        try:
+            logger.setLevel(chunk.node.verboseLevel.value.upper())
+
+            if not chunk.node.input:
+                logger.warning("Nothing to segment.")
+                return
+
+            logger.info("Chunk range from {} to {}".format(chunk.range.start, chunk.range.last))
+
+            chunk_image_paths = self._resolve_paths(chunk.node.input.value,
+                                                    chunk.node.inputMask.value, chunk.node.extensionMask.value,
+                                                    chunk.node.output.value, chunk.node.keepFilename.value,
+                                                    chunk.node.extensionOut.value)
+
+            if not os.path.exists(chunk.node.output.value):
+                os.mkdir(chunk.node.output.value)
+
+            device = torch.device("cuda") if torch.cuda.is_available() and chunk.node.useGpu.value else torch.device("cpu")
+            model_path = os.path.join(os.getenv("VIDEOMAMA_MODELS_PATH"), "fromSammieRoto")
+
+            try:
+                pipeline = videoMaMaUtils.VideoInferencePipeline(
+                    base_model_path=model_path,
+                    unet_checkpoint_path=model_path,
+                    weight_dtype=torch.float16,
+                    device=str(device),
+                    enable_model_cpu_offload=False, # Not much benefit here, since the vae is a small model
+                    vae_encode_chunk_size=1,        # Process VAE in small chunks, increasing doesnt help anything
+                    attention_mode="auto",          # Use xformers if available, else SDPA
+                    enable_vae_tiling=False,        # Tiling VAE is not worth it
+                    enable_vae_slicing=True,        # Process VAE one image at a time
+                )
+                print(f"Loaded videoMaMa model to {device}") # with max size {max_size}, overlap={overlap}, batch={batch_size}, and combined={combined}")
+            except Exception as e:
+                raise ValueError(f"Error loading VideoMaMa pipeline: {e}")
+
+            metadata_deep_model_base = {
+            "Meshroom:mrSegmentation:DeepModelName": "VideoMaMa",
+            "Meshroom:mrSegmentation:DeepModelVersion": "0.1",
+            "Meshroom:mrSegmentation:NodeVersion": "VideoMaMa-" + __version__
+            }
+
+            # bboxes.json decoding
+            json_path = os.path.join(chunk.node.inputMask.value, "bboxes.json")
+            frame_w = chunk_image_paths[0][5]
+            frame_h = chunk_image_paths[0][6]
+            par = chunk_image_paths[0][7]
+            firstFrameId = chunk_image_paths[0][2]
+            exp_factor = chunk.node.boxExtensionFactor.value
+            bboxes = bboxUtils.extract_tracking(json_path, frame_w, frame_h, False, False, False, False, exp_factor, par)
+            bboxes_metadata = bboxUtils.extract_tracking(json_path, frame_w, frame_h, False, False, False, False, exp_factor, par)
+            metadata_boxes = {}
+            for frameId in range(len(chunk_image_paths)):
+                metadata_boxes[firstFrameId + frameId] = {}
+
+            logger.debug(f"bboxes.keys() = {bboxes.keys()}")
+
+            full_alpha = {}
+            img, h_ori, w_ori, p_a_r, orientation = image.loadImage(str(chunk_image_paths[0][0]), True)
+            sourceInfo = {"h_ori": h_ori, "w_ori": w_ori, "PAR": p_a_r, "orientation": orientation}
+            for frameId, image_path in enumerate(chunk_image_paths):
+                full_alpha[image_path[2]] = np.zeros_like(img)
+
+            batch_size = chunk.node.batchSize.value
+            overlap = chunk.node.overlap.value
+
+            for key, frame_chunks in bboxes.items():
+
+                if "_" in key:
+                    textPrompt, obj_id = key.rsplit('_', 1)
+                else:
+                    textPrompt, obj_id = key, ""
+                logger.info(f"key = {key} ; text prompt = {textPrompt} ; obj_id = {obj_id}")
+
+                for frame_chunk in frame_chunks:
+                    logger.info(f"frame_chunk:\n{frame_chunk}")
+                    logger.debug(f"{frame_chunk.boxes}")
+
+                    total_frames = frame_chunk.end_frame - frame_chunk.start_frame + 1
+                    time_slices = self._generate_time_slices(total_frames, batch_size, overlap)
+                    logger.debug(f"time_slices = {time_slices}")
+
+                    cond_frames = []
+                    mask_frames = []
+                    for slice_idx, (slice_start, slice_end) in enumerate(time_slices):
+                        # startFrameId = firstFrameId + slice_start
+                        # stopFrameId = firstFrameId + slice_end
+                        startFrameId = frame_chunk.start_frame + slice_start
+                        stopFrameId = frame_chunk.start_frame + slice_end
+                        logger.info(f"slice #{slice_idx}/{len(time_slices)-1}: processing frames [{startFrameId}, {stopFrameId}[")
+                        if slice_idx > 0:
+                            cond_frames = cond_frames[-overlap:]
+                            mask_frames = mask_frames[-overlap:]
+                            startFrameId += overlap
+                        for frameId, box in frame_chunk.boxes.items():
+                            if frameId >= startFrameId and frameId < stopFrameId:
+                                #img, h_ori, w_ori, PAR, orientation = image.loadImage(str(chunk_image_paths[frameId - firstFrameId][0]), True)
+                                img, h_ori, w_ori, PAR, orientation = image.loadImage(str(chunk_image_paths[frameId - frame_chunk.start_frame][0]), True)
+                                x1, y1, x2, y2 = bboxUtils.box_to_display(box, sourceInfo["PAR"])
+                                imgBuf = oiio.ImageBuf(img)
+                                imgBuf = oiio.ImageBufAlgo.crop(imgBuf, roi=oiio.ROI(x1, x2, y1, y2))
+                                img_crop = imgBuf.get_pixels(format=oiio.FLOAT)
+                                frame = self._resize_image(img_crop, max(chunk.node.inferenceSize.value, 2160))
+                                resized_h, resized_w = frame.shape[:2]
+                                #mask_path = str(chunk_image_paths[frameId - firstFrameId][1])
+                                mask_path = str(chunk_image_paths[frameId - frame_chunk.start_frame][1])
+                                mask, h_ori_mask, w_ori_mask, PAR_mask, orientation_mask = image.loadImage(mask_path, True)
+                                imgBuf = oiio.ImageBuf(mask)
+                                imgBuf = oiio.ImageBufAlgo.crop(imgBuf, roi=oiio.ROI(x1, x2, y1, y2))
+                                img_crop = imgBuf.get_pixels(format=oiio.FLOAT)
+                                mask = cv2.resize(img_crop, (resized_w, resized_h), interpolation=cv2.INTER_NEAREST)
+                                cond_frames.append(frame)
+                                mask_frames.append(mask)
+                        nb, sh = self._check_lists_compatibility(cond_frames, mask_frames)
+                        logger.info(f"slice_idx = {slice_idx} ; {nb} frames ; shape = {sh}")
+
+                        try:
+                            with torch.amp.autocast('cuda', enabled=False):
+                                output_frames = pipeline.run(cond_frames=cond_frames, mask_frames=mask_frames, seed=42)
+                        except Exception as ex:
+                            logger.error(f"Error in VideoMaMa inference at slice {slice_idx}: {ex}")
+                            raise
+
+                        if len(output_frames) >= overlap and slice_idx < len(time_slices) - 1:
+                            previous_frames = output_frames[-overlap:].copy()
+                        if slice_idx == 0:
+                            mix_frames = output_frames[0:overlap]
+                        else:
+                            mix_frames = []
+                            for i in range(overlap):
+                                new_weight = (i + 1) / (overlap + 1)
+                                blended_frame = (1.0 - new_weight) * previous_frames[i] + new_weight * output_frames[i].copy()
+                                mix_frames.append(blended_frame)
+
+                        if slice_idx > 0:
+                            startFrameId -= overlap
+                        if slice_idx < len(time_slices) - 1:
+                            stopFrameId -= overlap
+
+                        for frameId, box in sorted(frame_chunk.boxes.items()):
+                            if frameId >= startFrameId and frameId < stopFrameId:
+                                frame_idx = frameId - startFrameId
+                                if frame_idx < batch_size - overlap or slice_idx == len(time_slices) - 1:
+                                    x1, y1, x2, y2 = bboxUtils.box_to_display(box, sourceInfo["PAR"])
+                                    box_w = x2 - x1
+                                    box_h = y2 - y1
+                                    output_frame = mix_frames[frame_idx].copy() if frame_idx < overlap else output_frames[frame_idx].copy()
+                                    alpha = self._restore_image_size(output_frame, (box_w, box_h))
+                                    full_alpha[frameId][y1:y2, x1:x2, :] = alpha
+
+            for key, frame_chunks in bboxes_metadata.items():
+                if "_" in key:
+                    textPrompt, obj_id = key.rsplit('_', 1)
+                else:
+                    textPrompt, obj_id = key, ""
+                for frame_chunk in frame_chunks:
+                    for frame_idx, box in sorted(frame_chunk.boxes.items()):
+                        if textPrompt not in metadata_boxes[frame_idx]:
+                            metadata_boxes[frame_idx][textPrompt] = {}
+                        x1, y1, x2, y2 = box
+                        bbox_str = str(x1) + ";" + str(y1)+ ";" + str(x2)+ ";" + str(y2)
+                        metadata_boxes[frame_idx][textPrompt][textPrompt + "_" + str(obj_id)] = bbox_str
+
+            for frameId, image_path in enumerate(chunk_image_paths):
+
+                optWrite = avimg.ImageWriteOptions()
+                optWrite.toColorSpace(avimg.EImageColorSpace_NO_CONVERSION)
+                if Path(image_path[4]).suffix.lower() == ".exr":
+                    optWrite.exrCompressionMethod(avimg.EImageExrCompression_stringToEnum("DWAA"))
+                    optWrite.exrCompressionLevel(300)
+
+                frame_metadata_deep_model = dict(metadata_deep_model_base)
+                for prompt, bboxes in metadata_boxes[firstFrameId + frameId].items():
+                    for k, box in metadata_boxes[firstFrameId + frameId][prompt].items():
+                            frame_metadata_deep_model["Meshroom:mrSegmentation:" + k] = box
+                alpha = full_alpha[image_path[2]]
+                image.writeImage(image_path[4], alpha, sourceInfo["h_ori"], sourceInfo["w_ori"], sourceInfo["orientation"],
+                                sourceInfo["PAR"], frame_metadata_deep_model, optWrite)
+
+        finally:
+            torch.cuda.empty_cache()

--- a/meshroom/videoMaMa/VideoMaMa.py
+++ b/meshroom/videoMaMa/VideoMaMa.py
@@ -144,9 +144,11 @@ class VideoMaMa(desc.Node):
                 if pinhole is not None:
                     par = pinhole.getPixelAspectRatio()
                 if keepFilename:
+                    filename = Path(inputFile).stem
                     if pathMask:
-                        inputFileMask = os.path.join(pathMask, Path(inputFile).stem + "." + extMask)
-                    outputFileMatte = os.path.join(outDir, Path(inputFile).stem + "." + extOut)
+                        mask_filename = "colorMask_%PROMPT%_fwd_" + str(filename)
+                        inputFileMask = os.path.join(pathMask, mask_filename + "." + extMask)
+                    outputFileMatte = os.path.join(outDir, filename + "." + extOut)
                 else:
                     if pathMask:
                         inputFileMask = os.path.join(pathMask, str(id) + "." + extMask)
@@ -305,6 +307,8 @@ class VideoMaMa(desc.Node):
             batch_size = chunk.node.batchSize.value
             overlap = chunk.node.overlap.value
 
+            colorPalette = image.paletteGenerator()
+
             for key, frame_chunks in bboxes.items():
 
                 if "_" in key:
@@ -337,16 +341,23 @@ class VideoMaMa(desc.Node):
                                 mask_frames = []
                         for frameId, box in frame_chunk.boxes.items():
                             if frameId >= startFrameId and frameId < stopFrameId:
-                                img, h_ori, w_ori, PAR, orientation = image.loadImage(str(chunk_image_paths[frameId - frame_chunk.start_frame][0]), True)
+                                img, h_ori, w_ori, PAR, orientation = image.loadImage(str(chunk_image_paths[frameId - firstFrameId][0]), True)
                                 x1, y1, x2, y2 = bboxUtils.box_to_display(box, sourceInfo["PAR"])
                                 imgBuf = oiio.ImageBuf(img)
                                 imgBuf = oiio.ImageBufAlgo.crop(imgBuf, roi=oiio.ROI(x1, x2, y1, y2))
                                 img_crop = imgBuf.get_pixels(format=oiio.FLOAT)
                                 method, frame = self._resize_image(img_crop, chunk.node.inferenceSize.value)
                                 resized_h, resized_w = frame.shape[:2]
-                                mask_path = str(chunk_image_paths[frameId - frame_chunk.start_frame][1])
-                                mask, h_ori_mask, w_ori_mask, PAR_mask, orientation_mask = image.loadImage(mask_path, True)
-                                imgBuf = oiio.ImageBuf(mask)
+                                mask_path = str(chunk_image_paths[frameId - firstFrameId][1])
+                                mask_path = mask_path.replace("%PROMPT%", textPrompt)
+                                mask, h_ori_mask, w_ori_mask, PAR_mask, orientation_mask = image.loadImage(mask_path, True, True, False)
+                                mask_uint8 = np.rint(np.clip(mask * 255, 0, 255)).astype(np.uint8)
+                                color_index = 0 if obj_id=="" else int(obj_id)
+                                colorPalette.generate_palette(color_index + 1)
+                                tgt = colorPalette.at(color_index)
+                                mask_id = np.zeros_like(img, dtype=np.float32)
+                                mask_id[(mask_uint8 == tgt).all(axis = -1)] = [1.0, 1.0, 1.0]
+                                imgBuf = oiio.ImageBuf(mask_id)
                                 imgBuf = oiio.ImageBufAlgo.crop(imgBuf, roi=oiio.ROI(x1, x2, y1, y2))
                                 img_crop = imgBuf.get_pixels(format=oiio.FLOAT)
                                 if method == "resize":

--- a/meshroom/vitMatte/ViTMatte.py
+++ b/meshroom/vitMatte/ViTMatte.py
@@ -387,10 +387,12 @@ Known Limitations:
                             matte = cv2.resize(matte.detach().cpu().numpy(), (w_inference, h_inference))
                             box_matteRGB = np.dstack([matte, matte, matte])
                             box_matteRGB = cv2.resize(box_matteRGB, (w_inference, h_inference), interpolation=cv2.INTER_LINEAR)
-                            matteRGB[y_top_inference:y_bottom_inference, x_left_inference:x_right_inference, :] = box_matteRGB
+                            tgt = matteRGB[y_top_inference:y_bottom_inference, x_left_inference:x_right_inference, :]
+                            matteRGB[y_top_inference:y_bottom_inference, x_left_inference:x_right_inference, :] = np.maximum(tgt, box_matteRGB)
 
                         trimap_for_inference = np.dstack([trimap_for_inference, trimap_for_inference, trimap_for_inference])
-                        fullTrimap[y_top_inference:y_bottom_inference, x_left_inference:x_right_inference, :] = trimap_for_inference
+                        tgt = fullTrimap[y_top_inference:y_bottom_inference, x_left_inference:x_right_inference, :]
+                        fullTrimap[y_top_inference:y_bottom_inference, x_left_inference:x_right_inference, :] = np.maximum(tgt, trimap_for_inference)
 
                         metadata_deep_model[key] = str(x_left_inference) + ";" + str(y_top_inference) + ";"
                         metadata_deep_model[key] += str(x_right_inference) + ";" + str(y_bottom_inference)

--- a/segmentationRDS/image.py
+++ b/segmentationRDS/image.py
@@ -111,13 +111,16 @@ def fromRawToUsualOrientation(x, y, width, height, PAR, orientation):
         x1 = xtmp
     return(x1, y1)
 
-def loadImage(imagePath: str, applyPAR: bool = False, applyOrientation: bool = True):
+def loadImage(imagePath: str, applyPAR: bool = False, applyOrientation: bool = True, srgb: bool = True):
     oiio_input = oiio.ImageInput.open(imagePath)
     oiio_spec = oiio_input.spec()
     oiio_input.close()
 
     av_image = avimg.Image_RGBfColor()
-    avOptRead = avimg.ImageReadOptions(avimg.EImageColorSpace_SRGB)
+    if srgb:
+        avOptRead = avimg.ImageReadOptions(avimg.EImageColorSpace_SRGB)
+    else:
+        avOptRead = avimg.ImageReadOptions(avimg.EImageColorSpace_NO_CONVERSION)
     avimg.readImage(imagePath, av_image, avOptRead)
     oiio_image = av_image.getNumpyArray()
 

--- a/segmentationRDS/videoMaMaUtils.py
+++ b/segmentationRDS/videoMaMaUtils.py
@@ -1,71 +1,5 @@
 import numpy as np
 import torch
-import cv2
-
-from diffusers.models import AutoencoderKLTemporalDecoder, UNetSpatioTemporalConditionModel
-
-
-def apply_mask_postprocessing(mask, holes=0, dots=0, border_fix=0, grow=0):
-    """Apply postprocessing to a mask using current session settings"""
-
-    if holes > 0:
-        mask = fill_small_holes(mask, holes)
-    if dots > 0:
-        mask = remove_small_dots(mask, dots)
-    if border_fix > 0:
-        mask = apply_border_fix(mask, border_fix)
-    if grow != 0:
-        mask = grow_shrink(mask, grow)
-
-    return mask
-
-def fill_small_holes(mask, holes_value):
-    max_hole_area = holes_value ** 2
-    filled_mask = mask.copy()
-    contours, hierarchy = cv2.findContours(mask, cv2.RETR_CCOMP, cv2.CHAIN_APPROX_SIMPLE)
-
-    for i, contour in enumerate(contours):
-        area = cv2.contourArea(contour)
-        if area <= max_hole_area and hierarchy[0][i][3] != -1:  # Check if it's a hole (child contour)
-            cv2.drawContours(filled_mask, [contour], -1, 255, thickness=cv2.FILLED)
-
-    return filled_mask
-
-def remove_small_dots(mask, dots_value):
-    max_dot_area = dots_value ** 2
-    num_labels, labels, stats, _ = cv2.connectedComponentsWithStats(mask, connectivity=8)
-
-    cleaned_mask = np.zeros_like(mask)
-    for label in range(1, num_labels):  # skip background
-        if stats[label, cv2.CC_STAT_AREA] > max_dot_area:
-            cleaned_mask[labels == label] = 255
-
-    return cleaned_mask
-
-def grow_shrink(mask, grow_value):
-    kernel = np.ones((abs(grow_value) + 1, abs(grow_value) + 1), np.uint8)
-    if grow_value > 0:
-        return cv2.dilate(mask, kernel, iterations=1)
-    elif grow_value < 0:
-        return cv2.erode(mask, kernel, iterations=1)
-    else:
-        return mask
-
-def apply_border_fix(mask, border_size):
-    if border_size == 0:
-        return mask
-    height, width = mask.shape
-    y_start = border_size
-    y_end = height - border_size
-    x_start = border_size
-    x_end = width - border_size
-    return cv2.copyMakeBorder(
-        mask[y_start:y_end, x_start:x_end],
-        border_size, border_size, border_size, border_size,
-        cv2.BORDER_REPLICATE,
-        value=None
-    )
-
 
 class VideoInferencePipeline:
     """
@@ -93,7 +27,6 @@ class VideoInferencePipeline:
             enable_vae_tiling (bool): Enable tiled VAE encoding/decoding for lower memory.
             enable_vae_slicing (bool): Enable VAE slicing to process one image at a time.
         """
-        #print("--- Initializing Inference Pipeline and Loading Models ---")
         self.device = torch.device(device)
         self.weight_dtype = weight_dtype
         self.enable_model_cpu_offload = enable_model_cpu_offload
@@ -101,6 +34,7 @@ class VideoInferencePipeline:
 
         # Load models from pretrained paths
         try:
+            from diffusers.models import AutoencoderKLTemporalDecoder, UNetSpatioTemporalConditionModel
             self.vae = AutoencoderKLTemporalDecoder.from_pretrained(base_model_path, subfolder="vae", variant="fp16")
             self.unet = UNetSpatioTemporalConditionModel.from_pretrained(unet_checkpoint_path, subfolder="unet")
         except Exception as e:
@@ -199,7 +133,7 @@ class VideoInferencePipeline:
             progress_callback: Optional callable(step, total_steps, description) for UI updates.
 
         Returns:
-            list[np.ndarray]: A list of the generated video frames as RGB uint8 arrays.
+            list[np.ndarray]: A list of the generated video frames as RGB float32 arrays in [0, 1]
         """
         def _notify(step, desc):
             """Notify progress via both pbar (ComfyUI) and callback (Sammie)"""
@@ -321,7 +255,7 @@ class VideoInferencePipeline:
             if arr.ndim == 2:
                 # Grayscale -> replicate to 3 channels
                 arr = np.stack([arr] * 3, axis=-1)
-            t = torch.from_numpy(arr.copy()).permute(2, 0, 1).float() # / 255.0  # (3, H, W) in [0, 1]
+            t = torch.from_numpy(arr.copy()).permute(2, 0, 1).float()
             tensors.append(t)
         video_tensor = torch.stack(tensors).unsqueeze(0)  # (1, F, 3, H, W)
         return video_tensor * 2.0 - 1.0  # normalize to [-1, 1]

--- a/segmentationRDS/videoMaMaUtils.py
+++ b/segmentationRDS/videoMaMaUtils.py
@@ -1,0 +1,356 @@
+import numpy as np
+import torch
+import cv2
+
+from diffusers.models import AutoencoderKLTemporalDecoder, UNetSpatioTemporalConditionModel
+
+
+def apply_mask_postprocessing(mask, holes=0, dots=0, border_fix=0, grow=0):
+    """Apply postprocessing to a mask using current session settings"""
+
+    if holes > 0:
+        mask = fill_small_holes(mask, holes)
+    if dots > 0:
+        mask = remove_small_dots(mask, dots)
+    if border_fix > 0:
+        mask = apply_border_fix(mask, border_fix)
+    if grow != 0:
+        mask = grow_shrink(mask, grow)
+
+    return mask
+
+def fill_small_holes(mask, holes_value):
+    max_hole_area = holes_value ** 2
+    filled_mask = mask.copy()
+    contours, hierarchy = cv2.findContours(mask, cv2.RETR_CCOMP, cv2.CHAIN_APPROX_SIMPLE)
+
+    for i, contour in enumerate(contours):
+        area = cv2.contourArea(contour)
+        if area <= max_hole_area and hierarchy[0][i][3] != -1:  # Check if it's a hole (child contour)
+            cv2.drawContours(filled_mask, [contour], -1, 255, thickness=cv2.FILLED)
+
+    return filled_mask
+
+def remove_small_dots(mask, dots_value):
+    max_dot_area = dots_value ** 2
+    num_labels, labels, stats, _ = cv2.connectedComponentsWithStats(mask, connectivity=8)
+
+    cleaned_mask = np.zeros_like(mask)
+    for label in range(1, num_labels):  # skip background
+        if stats[label, cv2.CC_STAT_AREA] > max_dot_area:
+            cleaned_mask[labels == label] = 255
+
+    return cleaned_mask
+
+def grow_shrink(mask, grow_value):
+    kernel = np.ones((abs(grow_value) + 1, abs(grow_value) + 1), np.uint8)
+    if grow_value > 0:
+        return cv2.dilate(mask, kernel, iterations=1)
+    elif grow_value < 0:
+        return cv2.erode(mask, kernel, iterations=1)
+    else:
+        return mask
+
+def apply_border_fix(mask, border_size):
+    if border_size == 0:
+        return mask
+    height, width = mask.shape
+    y_start = border_size
+    y_end = height - border_size
+    x_start = border_size
+    x_end = width - border_size
+    return cv2.copyMakeBorder(
+        mask[y_start:y_end, x_start:x_end],
+        border_size, border_size, border_size, border_size,
+        cv2.BORDER_REPLICATE,
+        value=None
+    )
+
+
+class VideoInferencePipeline:
+    """
+    A reusable pipeline for single-step video diffusion inference.
+
+    This class encapsulates the models and the core inference logic,
+    separating it from data loading and saving, which can vary between tasks.
+    """
+
+    def __init__(self, base_model_path: str, unet_checkpoint_path: str, device: str = "cuda",
+                 weight_dtype: torch.dtype = torch.float16, enable_model_cpu_offload: bool = False,
+                 vae_encode_chunk_size: int = 8, attention_mode: str = "auto",
+                 enable_vae_tiling: bool = False, enable_vae_slicing: bool = True):
+        """
+        Loads all necessary models into memory.
+
+        Args:
+            base_model_path (str): Path to the base Stable Video Diffusion model.
+            unet_checkpoint_path (str): Path to the fine-tuned UNet checkpoint.
+            device (str): The device to run models on ('cuda' or 'cpu').
+            weight_dtype (torch.dtype): The precision for model weights (float16 or bfloat16).
+            enable_model_cpu_offload (bool): If True, models are kept on CPU and moved to GPU only when needed.
+            vae_encode_chunk_size (int): Number of frames to encode at once in VAE (lower = less memory).
+            attention_mode (str): Attention optimization: 'auto', 'xformers', 'sdpa', or 'none'.
+            enable_vae_tiling (bool): Enable tiled VAE encoding/decoding for lower memory.
+            enable_vae_slicing (bool): Enable VAE slicing to process one image at a time.
+        """
+        #print("--- Initializing Inference Pipeline and Loading Models ---")
+        self.device = torch.device(device)
+        self.weight_dtype = weight_dtype
+        self.enable_model_cpu_offload = enable_model_cpu_offload
+        self.vae_encode_chunk_size = vae_encode_chunk_size
+
+        # Load models from pretrained paths
+        try:
+            self.vae = AutoencoderKLTemporalDecoder.from_pretrained(base_model_path, subfolder="vae", variant="fp16")
+            self.unet = UNetSpatioTemporalConditionModel.from_pretrained(unet_checkpoint_path, subfolder="unet")
+        except Exception as e:
+            raise IOError(f"Fatal error loading models: {e}")
+
+        # Set models to evaluation mode
+        self.vae.eval()
+        self.unet.eval()
+
+        # --- Apply attention optimizations ---
+        self._apply_attention_optimization(attention_mode)
+
+        # --- Apply VAE memory optimizations ---
+        if enable_vae_slicing:
+            try:
+                self.vae.enable_slicing()
+            except (AttributeError, NotImplementedError):
+                pass
+
+        if enable_vae_tiling:
+            try:
+                self.vae.enable_tiling()
+            except (AttributeError, NotImplementedError):
+                pass
+
+        if self.enable_model_cpu_offload:
+            # Keep models on CPU initially, move to GPU only when needed
+            self.vae.to("cpu", dtype=self.weight_dtype)
+            self.unet.to("cpu", dtype=self.weight_dtype)
+        else:
+            # Move all models to GPU
+            self.vae.to(self.device, dtype=self.weight_dtype)
+            self.unet.to(self.device, dtype=self.weight_dtype)
+
+    def _apply_attention_optimization(self, attention_mode: str):
+        """Apply memory-efficient attention to the UNet."""
+        if attention_mode == "none":
+            print("--- Attention optimization: DISABLED ---")
+            return
+
+        # Try xformers first if requested or auto
+        if attention_mode in ("auto", "xformers"):
+            try:
+                import xformers  # noqa: F401
+                self.unet.enable_xformers_memory_efficient_attention()
+                print("--- Attention optimization: xformers ENABLED ---")
+                return
+            except (ImportError, ModuleNotFoundError):
+                if attention_mode == "xformers":
+                    print("--- WARNING: xformers not installed, falling back to default attention ---")
+            except Exception as e:
+                print(f"--- WARNING: xformers failed ({e}), trying alternatives ---")
+
+        # Try PyTorch 2.0+ SDPA
+        if attention_mode in ("auto", "sdpa"):
+            if hasattr(torch.nn.functional, "scaled_dot_product_attention"):
+                try:
+                    from diffusers.models.attention_processor import AttnProcessor2_0
+                    self.unet.set_attn_processor(AttnProcessor2_0())
+                    #print("--- Attention optimization: PyTorch SDPA ENABLED ---")
+                    return
+                except Exception as e:
+                    if attention_mode == "sdpa":
+                        print(f"--- WARNING: SDPA setup failed ({e}) ---")
+            elif attention_mode == "sdpa":
+                print("--- WARNING: SDPA requires PyTorch 2.0+, falling back to default ---")
+
+        if attention_mode == "auto":
+            print("--- Attention optimization: using default attention ---")
+
+    @staticmethod
+    def _clear_device_cache(device):
+        """Clear cache for the appropriate device."""
+        if device.type == 'mps':
+            if torch.backends.mps.is_available():
+                torch.mps.empty_cache()
+        elif device.type == 'xpu':
+            torch.xpu.empty_cache()
+        elif device.type == 'cuda':
+            if torch.cuda.is_available():
+                torch.cuda.empty_cache()
+
+    def run(self, cond_frames, mask_frames, seed=42, fps=7, motion_bucket_id=127,
+            noise_aug_strength=0.0, pbar=None, progress_callback=None):
+        """
+        Runs the core inference process on a sequence of conditioning and mask frames.
+
+        Args:
+            cond_frames (list[np.ndarray]): List of RGB float arrays for conditioning.
+            mask_frames (list[np.ndarray]): List of RGB or grayscale float arrays for the masks.
+            seed (int): Random seed for generation.
+            fps (int): Frames per second to condition the model with.
+            motion_bucket_id (int): Motion bucket ID for conditioning.
+            noise_aug_strength (float): Noise augmentation strength.
+            pbar: Optional ComfyUI ProgressBar for progress tracking.
+            progress_callback: Optional callable(step, total_steps, description) for UI updates.
+
+        Returns:
+            list[np.ndarray]: A list of the generated video frames as RGB uint8 arrays.
+        """
+        def _notify(step, desc):
+            """Notify progress via both pbar (ComfyUI) and callback (Sammie)"""
+            if pbar is not None:
+                pbar.update(1)
+            if progress_callback is not None:
+                try:
+                    progress_callback(step, 5, desc)
+                except Exception:
+                    pass
+
+        # --- 1. Prepare Tensors ---
+        cond_video_tensor = self._cv2_to_tensor(cond_frames).to(self.device)
+        mask_video_tensor = self._cv2_to_tensor(mask_frames).to(self.device)
+
+        if mask_video_tensor.shape[2] != 3:
+            mask_video_tensor = mask_video_tensor.repeat(1, 1, 3, 1, 1)
+
+        with torch.no_grad():
+            # --- 2. Build zero image embeddings ---
+            # CLIP conditioning is not used by this fine-tuned model. The UNet was trained
+            # with zeroed encoder_hidden_states, so we construct the zero tensor directly
+            # using the UNet's expected cross_attention_dim rather than running CLIP.
+            hidden_size = self.unet.config.cross_attention_dim
+            encoder_hidden_states = torch.zeros(
+                (1, 1, hidden_size), dtype=self.weight_dtype, device=self.device
+            )
+
+            # --- 3. Prepare Latents ---
+            _notify(2, "VAE encoding...")
+            if self.enable_model_cpu_offload:
+                self.vae.to(self.device)
+
+            cond_latents = self._tensor_to_vae_latent(cond_video_tensor.to(self.weight_dtype), progress_callback=progress_callback, stage="Encoding video")
+            cond_latents = cond_latents / self.vae.config.scaling_factor
+            _notify(2, "VAE encoding...")
+            
+            
+
+            mask_latents = self._tensor_to_vae_latent(mask_video_tensor.to(self.weight_dtype), progress_callback=progress_callback, stage="Encoding mask")
+            mask_latents = mask_latents / self.vae.config.scaling_factor
+            _notify(2, "VAE encoding...")
+
+            # Free raw pixel tensors - no longer needed after VAE encoding
+            del cond_video_tensor, mask_video_tensor
+            self._clear_device_cache(self.device)
+
+            if self.enable_model_cpu_offload:
+                self.vae.to("cpu")
+                self._clear_device_cache(self.device)
+
+            # --- 4. Run UNet Single-Step Inference ---
+            _notify(3, "UNet inference...")
+            if self.enable_model_cpu_offload:
+                self.unet.to(self.device)
+
+            generator = torch.Generator(device="cpu").manual_seed(seed)
+            noisy_latents = torch.randn(cond_latents.shape, generator=generator, device="cpu",
+                                        dtype=self.weight_dtype).to(self.device)
+            timesteps = torch.full((1,), 1.0, device=self.device, dtype=torch.int32)
+            added_time_ids = self._get_add_time_ids(fps, motion_bucket_id, noise_aug_strength, batch_size=1)
+
+            unet_input = torch.cat([noisy_latents, cond_latents, mask_latents], dim=2)
+            # Free intermediate latents before UNet forward pass
+            del noisy_latents, cond_latents, mask_latents
+            self._clear_device_cache(self.device)
+
+            pred_latents = self.unet(unet_input, timesteps, encoder_hidden_states, added_time_ids=added_time_ids).sample
+            _notify(3, "UNet inference...")
+
+            del unet_input
+            if self.enable_model_cpu_offload:
+                self.unet.to("cpu")
+            self._clear_device_cache(self.device)
+
+            # --- 5. Decode Latents to Video Frames ---
+            _notify(4, "VAE decoding...")
+            if self.enable_model_cpu_offload:
+                self.vae.to(self.device)
+
+            pred_latents = (1 / self.vae.config.scaling_factor) * pred_latents.squeeze(0)
+
+            frames = []
+            # Process in chunks to avoid VRAM issues (lower = less memory, slower)
+            decode_chunk_size = min(self.vae_encode_chunk_size, pred_latents.shape[0])
+            for i in range(0, pred_latents.shape[0], decode_chunk_size):
+                if progress_callback is not None:
+                    progress_callback(i, pred_latents.shape[0], f"Decoding frame {i // decode_chunk_size + 1}")
+                chunk = pred_latents[i: i + decode_chunk_size]
+                decoded_chunk = self.vae.decode(chunk, num_frames=chunk.shape[0]).sample
+                frames.append(decoded_chunk.cpu())  # Move decoded frames to CPU immediately
+                _notify(4, "VAE decoding...")
+            del pred_latents
+            if self.enable_model_cpu_offload:
+                self.vae.to("cpu")
+            self._clear_device_cache(self.device)
+
+            _notify(5, "Writing frames...")
+
+            video_tensor = torch.cat(frames, dim=0)
+            del frames
+            video_tensor = (video_tensor / 2.0 + 0.5).clamp(0, 1).mean(dim=1, keepdim=True).repeat(1, 3, 1, 1)
+
+            # Return a list of RGB float32 frames
+            video_tensor = video_tensor.float().cpu()
+            output_frames = []
+            for frame in video_tensor:
+                # frame: (3, H, W), float [0, 1]
+                arr = frame.permute(1, 2, 0).numpy().clip(0, 1).astype(np.float32)
+                output_frames.append(arr)
+            return output_frames
+
+    def _cv2_to_tensor(self, frames: list) -> torch.Tensor:
+        """Converts a list of RGB float arrays (H, W, 3) or grayscale (H, W) arrays
+        to a normalized float video tensor of shape (1, F, 3, H, W) in [-1, 1]."""
+        tensors = []
+        for f in frames:
+            arr = np.asarray(f)
+            if arr.ndim == 2:
+                # Grayscale -> replicate to 3 channels
+                arr = np.stack([arr] * 3, axis=-1)
+            t = torch.from_numpy(arr.copy()).permute(2, 0, 1).float() # / 255.0  # (3, H, W) in [0, 1]
+            tensors.append(t)
+        video_tensor = torch.stack(tensors).unsqueeze(0)  # (1, F, 3, H, W)
+        return video_tensor * 2.0 - 1.0  # normalize to [-1, 1]
+
+    def _tensor_to_vae_latent(self, t: torch.Tensor, progress_callback=None, stage="VAE"):
+        """Encodes a video tensor into the VAE's latent space with optional chunking."""
+        batch_size, video_length = t.shape[0], t.shape[1]
+        t = t.reshape(t.shape[0] * t.shape[1], *t.shape[2:])
+
+        # Encode in chunks to reduce memory usage
+        latents_list = []
+        for i in range(0, t.shape[0], self.vae_encode_chunk_size):
+            if progress_callback is not None:
+                progress_callback(i, t.shape[0], f"{stage} frame {i // self.vae_encode_chunk_size + 1}")
+            chunk = t[i: i + self.vae_encode_chunk_size]
+            chunk_latents = self.vae.encode(chunk).latent_dist.sample()
+            latents_list.append(chunk_latents)
+
+        latents = torch.cat(latents_list, dim=0)
+        latents = latents.reshape(batch_size, video_length, *latents.shape[1:])
+        return latents * self.vae.config.scaling_factor
+
+    def _get_add_time_ids(self, fps, motion_bucket_id, noise_aug_strength, batch_size):
+        """Creates the additional time IDs for conditioning the UNet."""
+        add_time_ids_list = [fps, motion_bucket_id, noise_aug_strength]
+        passed_add_embed_dim = self.unet.config.addition_time_embed_dim * len(add_time_ids_list)
+        expected_add_embed_dim = self.unet.add_embedding.linear_1.in_features
+        if expected_add_embed_dim != passed_add_embed_dim:
+            raise ValueError(
+                f"Model expects an added time embedding vector of length {expected_add_embed_dim}, but a vector of {passed_add_embed_dim} was created.")
+        add_time_ids = torch.tensor([add_time_ids_list], dtype=self.weight_dtype, device=self.device)
+        return add_time_ids.repeat(batch_size, 1)


### PR DESCRIPTION
This pull request introduces significant enhancements to the video segmentation utilities, focusing on robust mask post-processing and a new, modular video inference pipeline. The changes aim to improve the quality of segmentation masks and streamline the process of running diffusion-based video inference, with attention to memory efficiency and flexibility.

**Mask Post-Processing Enhancements:**

* Added utility functions for mask post-processing, including filling small holes, removing small dots, growing/shrinking masks, and fixing borders, all configurable via parameters. (`segmentationRDS/videoMaMaUtils.py`)
* Updated the mask and trimap merging logic in `ViTMatte.py` to use `np.maximum` for combining overlapping regions, ensuring that the most prominent mask values are preserved during merging. (`meshroom/imageSegmentation/ViTMatte.py`)
