### PR TITLE
[sam3] Add and enable instance bonding for Sam3 nodes

### DIFF
--- a/meshroom/rotoPersons.mg
+++ b/meshroom/rotoPersons.mg
@@ -6,8 +6,8 @@
             "CameraInit": "12.1",
             "CopyFiles": "1.3",
             "ViTMatte": "1.0",
-            "VideoSegmentationSam3Boxes": "4.0",
-            "VideoSegmentationSam3Text": "1.2"
+            "VideoSegmentationSam3Boxes": "5.0",
+            "VideoSegmentationSam3Text": "2.0"
         },
         "template": true
     },
@@ -64,8 +64,10 @@
             ],
             "inputs": {
                 "input": "{CameraInit_1.output}",
+                "combineFwdAndBwdSeg": true,
                 "timeSlicing": true,
-                "sliceSize": 64
+                "sliceSize": 64,
+                "outputCryptomatte": true
             }
         }
     }

--- a/meshroom/sam3/ImageSegmentationSam3.py
+++ b/meshroom/sam3/ImageSegmentationSam3.py
@@ -1,4 +1,4 @@
-__version__ = "1.0"
+__version__ = "2.0"
 
 import os
 from pathlib import Path
@@ -8,27 +8,25 @@ from meshroom.core.utils import VERBOSE_LEVEL
 from pyalicevision import parallelization as avpar
 
 class ImageSegmentationSam3(desc.Node):
+    """
+Based on the Segment Anything model 3, the node generates a binary mask from a text prompt and a set of bounding boxes.
+The bounding boxes can be provided through a json file and loaded by clicking on a push button or manualy defined on the 2D viewer.
+When loaded from a json file containing rectangle shapes, the lowered shape name must contains the substring "pos" for the positive bounding boxes and "neg" for the negative ones.
+"""
     size = avpar.DynamicViewsSize("input")
     gpu = desc.Level.INTENSIVE
     parallelization = desc.Parallelization(blockSize=50)
 
     category = "Segmentation"
-    documentation = """
-Based on the Segment Anything model 3, the node generates a binary mask from a text prompt and a set of bounding boxes.
-The bounding boxes can be provided through a json file and loaded by clicking on a push button or manualy defined on the 2D viewer.
-When loaded from a json file containing rectangle shapes, the lowered shape name must contains the substring "pos" for the positive bounding boxes and "neg" for the negative ones.
-"""
 
     inputs = [
         desc.File(
             name="input",
-            label="Input",
             description="SfMData file.",
             value="",
         ),
         desc.StringParam(
             name="prompt",
-            label="Prompt",
             description="Text prompt, 1 concept per line.",
             value="person\nchild\npeople",
             semantic="multiline",
@@ -59,7 +57,6 @@ When loaded from a json file containing rectangle shapes, the lowered shape name
         ),
         desc.IntParam(
             name="bondingKernelSize",
-            label="Bonding Kernel Size",
             description="Kernel size for morphological processing applied for masks bonding.",
             value=11,
             range=(1, 255, 2),
@@ -80,7 +77,6 @@ When loaded from a json file containing rectangle shapes, the lowered shape name
         ),
         desc.BoolParam(
             name="keepFilename",
-            label="Keep Filename",
             description="Keep the filename of the inputs for the outputs.",
             value=True,
         ),
@@ -95,13 +91,11 @@ When loaded from a json file containing rectangle shapes, the lowered shape name
         ),
         desc.BoolParam(
             name="splitBoxPrompt",
-            label="Split Box Prompt",
             description="Reset detector before feeding with a new positive box and merge results. Negative boxes will be ignored.",
             value=False,
         ),
         desc.ChoiceParam(
             name="verboseLevel",
-            label="Verbose Level",
             description="Verbosity level (fatal, error, warning, info, debug).",
             value="info",
             values=VERBOSE_LEVEL,
@@ -142,7 +136,6 @@ When loaded from a json file containing rectangle shapes, the lowered shape name
         ),
         desc.File(
             name="masks",
-            label="Masks",
             description="Generated segmentation masks.",
             semantic="image",
             value=lambda attr: "{nodeCacheFolder}/" + ("<FILESTEM>" if attr.node.keepFilename.value else "<VIEW_ID>") + "." + attr.node.extensionOut.value,

--- a/meshroom/sam3/ImageSegmentationSam3.py
+++ b/meshroom/sam3/ImageSegmentationSam3.py
@@ -52,6 +52,19 @@ When loaded from a json file containing rectangle shapes, the lowered shape name
             value="${RDS_SAM3_MODEL_PATH}",
         ),
         desc.BoolParam(
+            name="enableBonding",
+            label="Enable Masks Bonding",
+            description="Enable bonding where instances overlap.",
+            value=True,
+        ),
+        desc.IntParam(
+            name="bondingKernelSize",
+            label="Bonding Kernel Size",
+            description="Kernel size for morphological processing applied for masks bonding.",
+            value=11,
+            enabled=lambda node: node.enableBonding.value,
+        ),
+        desc.BoolParam(
             name="maskInvert",
             label="Invert Masks",
             description="Invert mask values. If selected, the pixels corresponding to the mask will be set to 0 instead of 255.",
@@ -238,11 +251,17 @@ When loaded from a json file containing rectangle shapes, the lowered shape name
                 "height": xyxy[3] - xyxy[1]
                 }}
 
-    def updateMaskImageAndDetectedBboxes(self, inference_state, maskImage, detectedBBoxes, key, w_ori, h_ori, PAR, orientation):
-        from segmentationRDS import image
+    def updateMaskImageAndDetectedBboxes(self, inference_state, maskImage, detectedBBoxes, key, w_ori, h_ori, PAR, orientation, ks_bond = 0):
+        from segmentationRDS import image, sam3Utils
+        import numpy as np
         masks, boxes, scores = inference_state["masks"], inference_state["boxes"], inference_state["scores"]
-        for mask in masks:
-            maskImage[mask.squeeze(0).cpu()] = [255, 255, 255]
+        masks = [mask.squeeze(0).cpu().numpy() for mask in masks]
+        if masks:
+            masks_stack = np.stack(masks, axis=0)
+            bool_mask = np.sum(masks_stack, axis=0) > 0
+            if len(masks) > 1 and ks_bond > 0:
+                bool_mask = sam3Utils.bond_masks(masks, ks_bond, ks_bond, ks_bond) > 0
+            maskImage[bool_mask] = [255, 255, 255]
         for idx, box in enumerate(boxes):
             x1, y1, x2, y2 = box.cpu().tolist()
             x1, y1 = image.fromUsualToRawOrientation(x1, y1, w_ori, h_ori, PAR, orientation)
@@ -349,21 +368,24 @@ When loaded from a json file containing rectangle shapes, the lowered shape name
                         inference_state = processor.set_text_prompt(state=inference_state, prompt=textPrompt)
                         # Get the masks, bounding boxes, and scores
                         if "masks" in inference_state:
-                            self.updateMaskImageAndDetectedBboxes(inference_state, mask_image, detectedShapeBboxes, key, w_ori, h_ori, PAR, orientation)
+                            ks_bond = chunk.node.bondingKernelSize.value if chunk.node.enableBonding.value else 0
+                            self.updateMaskImageAndDetectedBboxes(inference_state, mask_image, detectedShapeBboxes, key, w_ori, h_ori, PAR, orientation, ks_bond)
 
-                    if not chunk.node.splitBoxPrompt:
+                    if not chunk.node.splitBoxPrompt.value:
                         processor.reset_all_prompts(state=inference_state)
                     for box, label in zip(bboxes, bboxLabels):
                         # Prompt the model with bboxes
-                        if chunk.node.splitBoxPrompt:
+                        if chunk.node.splitBoxPrompt.value:
                             processor.reset_all_prompts(state=inference_state)
                         inference_state = processor.add_geometric_prompt(state=inference_state, box=box, label=label)
                         # Get the masks, bounding boxes, and scores
-                        if "masks" in inference_state and label and chunk.node.splitBoxPrompt:
-                            self.updateMaskImageAndDetectedBboxes(inference_state, mask_image, detectedShapeBboxes, key, w_ori, h_ori, PAR, orientation)
+                        if "masks" in inference_state and label and chunk.node.splitBoxPrompt.value:
+                            ks_bond = chunk.node.bondingKernelSize.value if chunk.node.enableBonding.value else 0
+                            self.updateMaskImageAndDetectedBboxes(inference_state, mask_image, detectedShapeBboxes, key, w_ori, h_ori, PAR, orientation, ks_bond)
 
-                    if "masks" in inference_state and not chunk.node.splitBoxPrompt:
-                        self.updateMaskImageAndDetectedBboxes(inference_state, mask_image, detectedShapeBboxes, key, w_ori, h_ori, PAR, orientation)
+                    if "masks" in inference_state and not chunk.node.splitBoxPrompt.value:
+                        ks_bond = chunk.node.bondingKernelSize.value if chunk.node.enableBonding.value else 0
+                        self.updateMaskImageAndDetectedBboxes(inference_state, mask_image, detectedShapeBboxes, key, w_ori, h_ori, PAR, orientation, ks_bond)
 
                     if chunk.node.maskInvert.value:
                         mask = (mask_image[:,:,0:1] == 0).astype('float32')

--- a/meshroom/sam3/ImageSegmentationSam3.py
+++ b/meshroom/sam3/ImageSegmentationSam3.py
@@ -62,6 +62,7 @@ When loaded from a json file containing rectangle shapes, the lowered shape name
             label="Bonding Kernel Size",
             description="Kernel size for morphological processing applied for masks bonding.",
             value=11,
+            range=(1, 255, 2),
             enabled=lambda node: node.enableBonding.value,
         ),
         desc.BoolParam(

--- a/meshroom/sam3/ImageSegmentationSam3.py
+++ b/meshroom/sam3/ImageSegmentationSam3.py
@@ -10,8 +10,11 @@ from pyalicevision import parallelization as avpar
 class ImageSegmentationSam3(desc.Node):
     """
 Based on the Segment Anything model 3, the node generates a binary mask from a text prompt and a set of bounding boxes.
-The bounding boxes can be provided through a json file and loaded by clicking on a push button or manualy defined on the 2D viewer.
-When loaded from a json file containing rectangle shapes, the lowered shape name must contains the substring "pos" for the positive bounding boxes and "neg" for the negative ones.
+The bounding boxes can be provided through a JSON file and loaded by clicking on a push button or manualy defined on the
+2D viewer.
+
+When loaded from a JSON file containing rectangle shapes, the lowered shape name must contains the substring "pos" for the
+positive bounding boxes and "neg" for the negative ones.
 """
     size = avpar.DynamicViewsSize("input")
     gpu = desc.Level.INTENSIVE
@@ -65,7 +68,8 @@ When loaded from a json file containing rectangle shapes, the lowered shape name
         desc.BoolParam(
             name="maskInvert",
             label="Invert Masks",
-            description="Invert mask values. If selected, the pixels corresponding to the mask will be set to 0 instead of 255.",
+            description="Invert mask values. \n"
+                        "If selected, the pixels corresponding to the mask will be set to 0 instead of 255.",
             value=False,
         ),
         desc.BoolParam(
@@ -91,15 +95,9 @@ When loaded from a json file containing rectangle shapes, the lowered shape name
         ),
         desc.BoolParam(
             name="splitBoxPrompt",
-            description="Reset detector before feeding with a new positive box and merge results. Negative boxes will be ignored.",
+            description="Reset detector before feeding with a new positive box and merge results.\n"
+                        "Negative boxes will be ignored.",
             value=False,
-        ),
-        desc.ChoiceParam(
-            name="verboseLevel",
-            description="Verbosity level (fatal, error, warning, info, debug).",
-            value="info",
-            values=VERBOSE_LEVEL,
-            exclusive=True,
         ),
         desc.ShapeList(
             name="positiveBoxes",
@@ -125,6 +123,13 @@ When loaded from a json file containing rectangle shapes, the lowered shape name
                 keyType="viewId",
             ),
         ),
+        desc.ChoiceParam(
+            name="verboseLevel",
+            description="Verbosity level (fatal, error, warning, info, debug).",
+            value="info",
+            values=VERBOSE_LEVEL,
+            exclusive=True,
+        ),
     ]
 
     outputs = [
@@ -144,7 +149,7 @@ When loaded from a json file containing rectangle shapes, the lowered shape name
 
     def onBboxLoadClicked(self, node):
         import json
-        from pathlib import Path
+
         if node.bboxFolder.value:
             shapeFiles = list(Path(node.bboxFolder.value).glob("*shapes.json"))
             if len(shapeFiles) > 0:
@@ -174,7 +179,6 @@ When loaded from a json file containing rectangle shapes, the lowered shape name
     def resolvedPaths(self, input_path, outDir, keepFilename, extensionOut):
         from pyalicevision import sfmData
         from pyalicevision import sfmDataIO
-        from pathlib import Path
 
         paths = {}
         if Path(input_path).suffix.lower() in [".sfm", ".abc"]:
@@ -182,16 +186,16 @@ When loaded from a json file containing rectangle shapes, the lowered shape name
                 dataAV = sfmData.SfMData()
                 if sfmDataIO.load(dataAV, input_path, sfmDataIO.ALL) and os.path.isdir(outDir):
                     views = dataAV.getViews()
-                    for id, v in views.items():
+                    for vId, v in views.items():
                         inputFile = v.getImage().getImagePath()
                         frameId = v.getFrameId()
                         if keepFilename:
                             outputFileMask = os.path.join(outDir, Path(inputFile).stem + "." + extensionOut)
                             outputFileBoxes = os.path.join(outDir, "bboxes_" + Path(inputFile).stem + ".jpg")
                         else:
-                            outputFileMask = os.path.join(outDir, str(id) + "." + extensionOut)
-                            outputFileBoxes = os.path.join(outDir, "bboxes_" + str(id) + ".jpg")
-                        paths[inputFile] = (outputFileMask, outputFileBoxes, frameId, str(id))
+                            outputFileMask = os.path.join(outDir, str(vId) + "." + extensionOut)
+                            outputFileBoxes = os.path.join(outDir, "bboxes_" + str(vId) + ".jpg")
+                        paths[inputFile] = (outputFileMask, outputFileBoxes, frameId, str(vId))
 
         return paths
 
@@ -245,10 +249,11 @@ When loaded from a json file containing rectangle shapes, the lowered shape name
                 "height": xyxy[3] - xyxy[1]
                 }}
 
-    def updateMaskImageAndDetectedBboxes(self, inference_state, maskImage, detectedBBoxes, key, w_ori, h_ori, PAR, orientation, ks_bond = 0):
+    def updateMaskImageAndDetectedBboxes(self, inference_state, maskImage, detectedBBoxes, key,
+                                         w_ori, h_ori, PAR, orientation, ks_bond = 0):
         from segmentationRDS import image, sam3Utils
         import numpy as np
-        masks, boxes, scores = inference_state["masks"], inference_state["boxes"], inference_state["scores"]
+        masks, boxes = inference_state["masks"], inference_state["boxes"]
         masks = [mask.squeeze(0).cpu().numpy() for mask in masks]
         if masks:
             masks_stack = np.stack(masks, axis=0)
@@ -303,7 +308,8 @@ When loaded from a json file containing rectangle shapes, the lowered shape name
 
             chunk.logger.info("Chunk range from {} to {}".format(chunk.range.start, chunk.range.last))
 
-            outFiles = self.resolvedPaths(chunk.node.input.value, chunk.node.output.value, chunk.node.keepFilename.value, chunk.node.extensionOut.value)
+            outFiles = self.resolvedPaths(chunk.node.input.value, chunk.node.output.value,
+                                          chunk.node.keepFilename.value, chunk.node.extensionOut.value)
 
             if not os.path.exists(chunk.node.output.value):
                 os.mkdir(chunk.node.output.value)
@@ -326,13 +332,13 @@ When loaded from a json file containing rectangle shapes, the lowered shape name
             detectedShapeBboxes = []
 
             for k, (iFile, oFile) in enumerate(outFiles.items()):
-                if k >= chunk.range.start and k <= chunk.range.last:
+                if chunk.range.start <= k <= chunk.range.last:
                     img, h_ori, w_ori, PAR, orientation = image.loadImage(iFile, True)
                     frameId = oFile[2]
                     viewId = oFile[3]
                     key = iFile if viewId == "not_a_view" else viewId
 
-                    chunk.logger.info("frameId: {} - {}".format(frameId, iFile))
+                    chunk.logger.info(f"frameId: {frameId} - {iFile}")
 
                     bboxes = []
                     bboxLabels = []

--- a/meshroom/sam3/VideoSegmentationSam3.py
+++ b/meshroom/sam3/VideoSegmentationSam3.py
@@ -1,4 +1,4 @@
-__version__ = "1.0"
+__version__ = "2.0"
 
 import os
 from pathlib import Path
@@ -12,27 +12,25 @@ import logging
 logger = logging.getLogger("VideoSegmentationSam3")
 
 class VideoSegmentationSam3(desc.Node):
-    size = avpar.DynamicViewsSize("input")
-    gpu = desc.Level.EXTREME
-
-    category = "Segmentation"
-    documentation = """
+    """
 Based on the Segment Anything video predictor model 3, the node generates a binary mask, a colored mask and an exr cryptomatte
 from a text prompt, a single bounding box or a set of positive and negative clicks (Clicks In/Out).
 Text prompt and Clicks can be combined to refine results. For refinement, points must be associated to an existing submask.
 In order to associate a point to a given submask, it must be colored with the submask's color.
 """
+    size = avpar.DynamicViewsSize("input")
+    gpu = desc.Level.EXTREME
+
+    category = "Segmentation"
 
     inputs = [
         desc.File(
             name="input",
-            label="Input",
             description="SfMData file.",
             value="",
         ),
         desc.StringParam(
             name="prompt",
-            label="Prompt",
             description="What to segment, separated by point or one item per line.",
             value="person",
             semantic="multiline",
@@ -51,13 +49,11 @@ In order to associate a point to a given submask, it must be colored with the su
         ),
         desc.BoolParam(
             name="timeSlicing",
-            label="Time Slicing",
             description="Enable time slicing by adding text prompt every N frames and by propagating forward on N frames.",
             value=False,
         ),
         desc.IntParam(
             name="sliceSize",
-            label="Slice Size",
             description="Number of frames on which the mask is propagated.",
             value=16,
             enabled=lambda node: node.timeSlicing.value,
@@ -70,7 +66,6 @@ In order to associate a point to a given submask, it must be colored with the su
         ),
         desc.IntParam(
             name="bondingKernelSize",
-            label="Bonding Kernel Size",
             description="Kernel size for morphological processing applied for masks bonding.",
             value=11,
             range=(1, 255, 2),
@@ -84,7 +79,6 @@ In order to associate a point to a given submask, it must be colored with the su
         ),
         desc.BoolParam(
             name="outputCryptomatte",
-            label="Output Cryptomatte",
             description="Generate exr images containing cryptomatte to encode the segmentation results.",
             value=False,
         ),
@@ -97,7 +91,6 @@ In order to associate a point to a given submask, it must be colored with the su
         ),
         desc.BoolParam(
             name="keepFilename",
-            label="Keep Filename",
             description="Keep the filename of the inputs for the outputs.",
             value=True,
         ),
@@ -136,14 +129,12 @@ In order to associate a point to a given submask, it must be colored with the su
         ),
         desc.Rectangle(
             name="boxPrompt",
-            label="Box Prompt",
             description="Single bounding box used as initial prompt.",
             keyable=True,
             keyType="viewId"
         ),
         desc.ChoiceParam(
             name="verboseLevel",
-            label="Verbose Level",
             description="Verbosity level (fatal, error, warning, info, debug).",
             value="info",
             values=VERBOSE_LEVEL,
@@ -160,7 +151,6 @@ In order to associate a point to a given submask, it must be colored with the su
         ),
         desc.File(
             name="masks",
-            label="Masks",
             description="Generated segmentation masks.",
             semantic="image",
             value=lambda attr: "{nodeCacheFolder}/" + ("<FILESTEM>" if attr.node.keepFilename.value else "<VIEW_ID>") + "." + attr.node.extensionOut.value,
@@ -174,7 +164,6 @@ In order to associate a point to a given submask, it must be colored with the su
         ),
         desc.File(
             name="cryptomatte",
-            label="Cryptomatte",
             description="Cryptomatte embedded in exr images.",
             semantic="image",
             value=lambda attr: "{nodeCacheFolder}/cryptomatte_" + ("<FILESTEM>" if attr.node.keepFilename.value else "<VIEW_ID>") + ".exr",

--- a/meshroom/sam3/VideoSegmentationSam3.py
+++ b/meshroom/sam3/VideoSegmentationSam3.py
@@ -73,6 +73,7 @@ In order to associate a point to a given submask, it must be colored with the su
             label="Bonding Kernel Size",
             description="Kernel size for morphological processing applied for masks bonding.",
             value=11,
+            range=(1, 255, 2),
             enabled=lambda node: node.enableBonding.value,
         ),
         desc.BoolParam(

--- a/meshroom/sam3/VideoSegmentationSam3.py
+++ b/meshroom/sam3/VideoSegmentationSam3.py
@@ -1,5 +1,6 @@
 __version__ = "2.0"
 
+import logging
 import os
 from pathlib import Path
 import struct
@@ -8,13 +9,13 @@ from meshroom.core import desc
 from meshroom.core.utils import VERBOSE_LEVEL
 from pyalicevision import parallelization as avpar
 
-import logging
 logger = logging.getLogger("VideoSegmentationSam3")
 
 class VideoSegmentationSam3(desc.Node):
     """
 Based on the Segment Anything video predictor model 3, the node generates a binary mask, a colored mask and an exr cryptomatte
 from a text prompt, a single bounding box or a set of positive and negative clicks (Clicks In/Out).
+
 Text prompt and Clicks can be combined to refine results. For refinement, points must be associated to an existing submask.
 In order to associate a point to a given submask, it must be colored with the submask's color.
 """
@@ -22,6 +23,8 @@ In order to associate a point to a given submask, it must be colored with the su
     gpu = desc.Level.EXTREME
 
     category = "Segmentation"
+
+    image_paths = []
 
     inputs = [
         desc.File(
@@ -295,9 +298,7 @@ In order to associate a point to a given submask, it must be colored with the su
         import OpenImageIO as oiio
 
         try:
-
             self.resolvePaths(chunk.node)
-            
             logger.setLevel(chunk.node.verboseLevel.value.upper())
 
             if not chunk.node.input:
@@ -353,10 +354,10 @@ In order to associate a point to a given submask, it must be colored with the su
 
             logger.debug(f"frameIdxToTextPromptFwd: {frameIdxToTextPrompt_fwd}")
             logger.debug(f"frameIdxToTextPromptBwd: {frameIdxToTextPrompt_bwd}")
-            
-            for idx, path in enumerate(chunk_image_paths):
+
+            for idx, _ in enumerate(chunk_image_paths):
                 img, h_ori, w_ori, PAR, orientation = image.loadImage(str(chunk_image_paths[idx][0]), True)
-                pil_images.append(Image.fromarray((255.0*img).astype("uint8")))
+                pil_images.append(Image.fromarray((255.0 * img).astype("uint8")))
                 sourceInfo = {"h_ori": h_ori, "w_ori": w_ori, "PAR": PAR, "orientation": orientation}
 
                 viewId = chunk_image_paths[idx][1]
@@ -495,8 +496,9 @@ In order to associate a point to a given submask, it must be colored with the su
 
                 if chunk.node.outputCryptomatte.value:
                     spec = oiio.ImageSpec(img.shape[1], img.shape[0], 7, oiio.FLOAT)
-                    spec.channelnames = (cryptoName+".red", cryptoName+".green", cryptoName+".blue",
-                                        cryptoName+"00.red", cryptoName+"00.green", cryptoName+"00.blue", cryptoName+"00.alpha")
+                    spec.channelnames = (cryptoName + ".red", cryptoName + ".green", cryptoName + ".blue",
+                                         cryptoName + "00.red", cryptoName + "00.green", cryptoName + "00.blue",
+                                         cryptoName + "00.alpha")
                     _, _, h32 = self.hash_name(cryptoName)
                     crypto_key = f"{h32 & 0xFFFFFFFF:08x}"[:7]
                     spec.attribute(f"cryptomatte/{crypto_key}/name", cryptoName)
@@ -505,28 +507,35 @@ In order to associate a point to a given submask, it must be colored with the su
                     spec.attribute(f"cryptomatte/{crypto_key}/conversion", "uint32_to_float32")
 
                     if chunk.node.keepFilename.value:
-                        cryptomattePath = os.path.join(chunk.node.output.value, "cryptomatte_" + str(Path(chunk_image_paths[frameId][0]).stem) + ".exr")
+                        cryptomattePath = os.path.join(chunk.node.output.value, "cryptomatte_" +
+                                                       str(Path(chunk_image_paths[frameId][0]).stem) + ".exr")
                     else:
-                        cryptomattePath = os.path.join(chunk.node.output.value, "cryptomatte_" + str(chunk_image_paths[frameId][1]) + ".exr")
+                        cryptomattePath = os.path.join(chunk.node.output.value, "cryptomatte_" +
+                                                       str(chunk_image_paths[frameId][1]) + ".exr")
 
                     cryptomatteImg = oiio.ImageOutput.create(str(cryptomattePath))
                     cryptomatteImg.open(cryptomattePath, spec)
-                    cryptomatte_data = np.dstack((crypto_zeros, crypto_zeros, crypto_zeros, crypto_id, crypto_cov, crypto_zeros, crypto_zeros))
+                    cryptomatte_data = np.dstack((crypto_zeros, crypto_zeros, crypto_zeros, crypto_id, crypto_cov,
+                                                  crypto_zeros, crypto_zeros))
                     cryptomatteImg.write_image(cryptomatte_data)
                     cryptomatteImg.close()
 
                 if chunk.node.maskInvert.value:
-                    mask = (maskImage[:,:,0:1] == 0).astype('float32')
+                    mask = (maskImage[:, :, 0:1] == 0).astype('float32')
                 else:
-                    mask = (maskImage[:,:,0:1] > 0).astype('float32')
-                logger.info("frameId: {} - {}".format(frameId, chunk_image_paths[frameId][0]))
+                    mask = (maskImage[:, :, 0:1] > 0).astype('float32')
+                logger.info(f"frameId: {frameId} - {chunk_image_paths[frameId][0]}")
 
                 if chunk.node.keepFilename.value:
-                    outputFileMask = os.path.join(chunk.node.output.value, Path(chunk_image_paths[frameId][0]).stem + "." + chunk.node.extensionOut.value)
-                    outputFileColorMask = os.path.join(chunk.node.output.value, "colorMask_" + str(Path(chunk_image_paths[frameId][0]).stem) + ".png")
+                    outputFileMask = os.path.join(chunk.node.output.value, Path(chunk_image_paths[frameId][0]).stem +
+                                                  "." + chunk.node.extensionOut.value)
+                    outputFileColorMask = os.path.join(chunk.node.output.value, "colorMask_" +
+                                                       str(Path(chunk_image_paths[frameId][0]).stem) + ".png")
                 else:
-                    outputFileMask = os.path.join(chunk.node.output.value, str(chunk_image_paths[frameId][1]) + "." + chunk.node.extensionOut.value)
-                    outputFileColorMask = os.path.join(chunk.node.output.value, "colorMask_" + str(chunk_image_paths[frameId][1]) + ".png")
+                    outputFileMask = os.path.join(chunk.node.output.value, str(chunk_image_paths[frameId][1]) + "." +
+                                                  chunk.node.extensionOut.value)
+                    outputFileColorMask = os.path.join(chunk.node.output.value, "colorMask_" +
+                                                       str(chunk_image_paths[frameId][1]) + ".png")
 
                 optWrite = avimg.ImageWriteOptions()
                 optWrite.toColorSpace(avimg.EImageColorSpace_NO_CONVERSION)
@@ -534,8 +543,10 @@ In order to associate a point to a given submask, it must be colored with the su
                     optWrite.exrCompressionMethod(avimg.EImageExrCompression_stringToEnum("DWAA"))
                     optWrite.exrCompressionLevel(300)
 
-                image.writeImage(outputFileMask, mask, sourceInfo["h_ori"], sourceInfo["w_ori"], sourceInfo["orientation"], sourceInfo["PAR"], metadata_deep_model, optWrite)
-                image.writeImage(outputFileColorMask, colorMaskImage, sourceInfo["h_ori"], sourceInfo["w_ori"], sourceInfo["orientation"], sourceInfo["PAR"], metadata_deep_model, optWrite)
+                image.writeImage(outputFileMask, mask, sourceInfo["h_ori"], sourceInfo["w_ori"],
+                                 sourceInfo["orientation"], sourceInfo["PAR"], metadata_deep_model, optWrite)
+                image.writeImage(outputFileColorMask, colorMaskImage, sourceInfo["h_ori"], sourceInfo["w_ori"],
+                                 sourceInfo["orientation"], sourceInfo["PAR"], metadata_deep_model, optWrite)
 
         finally:
             torch.cuda.empty_cache()
@@ -544,7 +555,6 @@ In order to associate a point to a given submask, it must be colored with the su
 def get_image_paths_list(input_path):
     from pyalicevision import sfmData
     from pyalicevision import sfmDataIO
-    from pathlib import Path
 
     image_paths = []
 
@@ -553,8 +563,8 @@ def get_image_paths_list(input_path):
             dataAV = sfmData.SfMData()
             if sfmDataIO.load(dataAV, input_path, sfmDataIO.ALL):
                 views = dataAV.getViews()
-                for id, v in views.items():
-                   image_paths.append((Path(v.getImage().getImagePath()), str(id), v.getFrameId()))
+                for vId, v in views.items():
+                    image_paths.append((Path(v.getImage().getImagePath()), str(vId), v.getFrameId()))
 
             image_paths.sort(key=lambda x: x[0])
     else:

--- a/meshroom/sam3/VideoSegmentationSam3.py
+++ b/meshroom/sam3/VideoSegmentationSam3.py
@@ -63,6 +63,19 @@ In order to associate a point to a given submask, it must be colored with the su
             enabled=lambda node: node.timeSlicing.value,
         ),
         desc.BoolParam(
+            name="enableBonding",
+            label="Enable Masks Bonding",
+            description="Enable bonding where instances overlap.",
+            value=True,
+        ),
+        desc.IntParam(
+            name="bondingKernelSize",
+            label="Bonding Kernel Size",
+            description="Kernel size for morphological processing applied for masks bonding.",
+            value=11,
+            enabled=lambda node: node.enableBonding.value,
+        ),
+        desc.BoolParam(
             name="maskInvert",
             label="Invert Masks",
             description="Invert mask values. If selected, the pixels corresponding to the mask will be set to 0 instead of 255.",
@@ -283,7 +296,7 @@ In order to associate a point to a given submask, it must be colored with the su
 
     def processChunk(self, chunk):
         import json
-        from segmentationRDS import image
+        from segmentationRDS import image, sam3Utils
         from sam3.model_builder import build_sam3_video_predictor
         import numpy as np
         import torch
@@ -462,8 +475,16 @@ In order to associate a point to a given submask, it must be colored with the su
                 if len(masks.keys()) > 0:
                     colorPalette.generate_palette(max(masks.keys()) + 1)
                 cryptoName = "object" if prompt == "" else prompt
+
+                if masks.keys():
+                    masks_stack = np.stack(list(masks.values()), axis=0)
+                    bool_mask = np.sum(masks_stack, axis=0) > 0
+                    if len(masks.values()) > 1 and chunk.node.enableBonding.value:
+                        ks = chunk.node.bondingKernelSize.value
+                        bool_mask = sam3Utils.bond_masks(list(masks.values()), ks, ks, ks) > 0
+                    maskImage[bool_mask] = [255, 255, 255]
+
                 for key, mask in masks.items():
-                    maskImage[mask] = [255, 255, 255]
                     color = colorPalette.at(int(key)) if colorPalette.at(int(key)) is not None else [255, 255, 255]
                     colorMaskImage[mask] = [x/255.0 for x in color]
                     if chunk.node.outputCryptomatte.value:
@@ -472,9 +493,15 @@ In order to associate a point to a given submask, it must be colored with the su
                         manifest[obj_name] = hex_val
                         crypto_id[mask] = f32_hash
                         crypto_cov[mask] = 1.0
+
                 if frameId in outputs_per_frame_bwd.keys():
-                    for key, mask in outputs_per_frame_bwd[frameId].items():
-                        maskImage[mask] = [255, 255, 255]
+                    if outputs_per_frame_bwd[frameId].keys():
+                        masks_stack = np.stack(list(outputs_per_frame_bwd[frameId].values()), axis=0)
+                        bool_mask = np.sum(masks_stack, axis=0) > 0
+                        if len(outputs_per_frame_bwd[frameId].values()) > 1 and chunk.node.enableBonding.value:
+                            ks = chunk.node.bondingKernelSize.value
+                            bool_mask = sam3Utils.bond_masks(list(outputs_per_frame_bwd[frameId].values()), ks, ks, ks) > 0
+                        maskImage[bool_mask] = [255, 255, 255]
 
                 if chunk.node.outputCryptomatte.value:
                     spec = oiio.ImageSpec(img.shape[1], img.shape[0], 7, oiio.FLOAT)

--- a/meshroom/sam3/VideoSegmentationSam3Boxes.py
+++ b/meshroom/sam3/VideoSegmentationSam3Boxes.py
@@ -196,6 +196,7 @@ Bounding box metadata is embedded under the `Meshroom:mrSegmentation:` namespace
             label="Bonding Kernel Size",
             description="Kernel size for morphological processing applied for masks bonding.",
             value=11,
+            range=(1, 255, 2),
             enabled=lambda node: node.enableBonding.value,
         ),
         desc.File(

--- a/meshroom/sam3/VideoSegmentationSam3Boxes.py
+++ b/meshroom/sam3/VideoSegmentationSam3Boxes.py
@@ -82,7 +82,7 @@ For each tracked object:
 3. Each chunk is split into tiles (if tiling enabled).
 4. Cropped image sequences are fed to the SAM3 video predictor with a text prompt on the first frame;
    masks are propagated across all frames.
-5. Tile masks are resized and composited into full-resolution masks using a **union** operation.
+5. Tile masks are resized and composited into full-resolution masks using a **union** operation and optional bonding.
 6. *(Tiling only)* Tiles with IoU below `minIoU` are replaced by the coarse mask crop.
 7. Masks are saved with optional inversion and bounding box metadata in file headers.
 
@@ -184,6 +184,19 @@ Bounding box metadata is embedded under the `Meshroom:mrSegmentation:` namespace
             description="Minimal IoU between coarse and fine mask within a tile to keep the fine mask.",
             value=0.5,
             enabled=lambda node: node.enableTiling.value,
+        ),
+        desc.BoolParam(
+            name="enableBonding",
+            label="Enable Masks Bonding",
+            description="Enable bonding where instances overlap.",
+            value=True,
+        ),
+        desc.IntParam(
+            name="bondingKernelSize",
+            label="Bonding Kernel Size",
+            description="Kernel size for morphological processing applied for masks bonding.",
+            value=11,
+            enabled=lambda node: node.enableBonding.value,
         ),
         desc.File(
             name="segmentationModelPath",
@@ -471,12 +484,19 @@ Bounding box metadata is embedded under the `Meshroom:mrSegmentation:` namespace
                                 fine_mask = np.zeros_like(tgt)
                                 frameId = frame_idx - chunk_tile.start_frame
                                 logger.debug(f"frame: {frame_idx}; tile: {box}; items number: {len(outputs_per_frame_visu[frameId].keys())}")
+                                masks = []
                                 for key, maskBoxProb in outputs_per_frame_visu[frameId].items():
                                     mask = maskBoxProb["mask"]
                                     buf_in = oiio.ImageBuf(mask.astype('float32'))
                                     buf_out = oiio.ImageBufAlgo.resample(buf_in, roi=oiio.ROI(0, box_w, 0, box_h))
                                     mask = buf_out.get_pixels().reshape(box_h, box_w, 1)
-                                    bool_mask = mask.squeeze() > 0
+                                    masks.append(mask.squeeze())
+
+                                if masks:
+                                    bool_mask = masks[0] > 0
+                                    if len(masks) > 1 and chunk.node.enableBonding.value:
+                                        ks = chunk.node.bondingKernelSize.value
+                                        bool_mask = sam3Utils.bond_masks(masks, ks, ks, ks) > 0
                                     fine_mask[bool_mask] = [255, 255, 255] if maskNbChannel == 3 else [255]
 
                                 if chunk.node.enableTiling.value:

--- a/meshroom/sam3/VideoSegmentationSam3Boxes.py
+++ b/meshroom/sam3/VideoSegmentationSam3Boxes.py
@@ -493,7 +493,8 @@ Bounding box metadata is embedded under the `Meshroom:mrSegmentation:` namespace
                                     masks.append(mask.squeeze())
 
                                 if masks:
-                                    bool_mask = masks[0] > 0
+                                    masks_stack = np.stack(masks, axis=0)
+                                    bool_mask = np.sum(masks_stack, axis=0) > 0
                                     if len(masks) > 1 and chunk.node.enableBonding.value:
                                         ks = chunk.node.bondingKernelSize.value
                                         bool_mask = sam3Utils.bond_masks(masks, ks, ks, ks) > 0

--- a/meshroom/sam3/VideoSegmentationSam3Boxes.py
+++ b/meshroom/sam3/VideoSegmentationSam3Boxes.py
@@ -1,5 +1,6 @@
 __version__ = "5.0"
 
+import logging
 import os
 from pathlib import Path
 
@@ -7,7 +8,6 @@ from meshroom.core import desc
 from meshroom.core.utils import VERBOSE_LEVEL
 from pyalicevision import parallelization as avpar
 
-import logging
 logger = logging.getLogger("VideoSegmentationSam3Boxes")
 
 class VideoSegmentationSam3Boxes(desc.Node):
@@ -96,6 +96,8 @@ Bounding box metadata is embedded under the `Meshroom:mrSegmentation:` namespace
     # _cuda_tag = "cuda24G"
 
     category = "Segmentation"
+
+    image_paths = []
 
     inputs = [
         desc.File(
@@ -377,14 +379,15 @@ Bounding box metadata is embedded under the `Meshroom:mrSegmentation:` namespace
                         pil_images = []
                         for frameId, box in chunk_tiles[0].boxes.items():
                             if not chunk.node.computeOnFirstFrameOnly.value or frameId == chunk_image_paths[0][2]:
-                                img, h_ori, w_ori, PAR, orientation = image.loadImage(str(chunk_image_paths[frameId - firstFrameId][0]), True)
+                                idx = frameId - firstFrameId
+                                img, h_ori, w_ori, _, orientation = image.loadImage(str(chunk_image_paths[idx][0]), True)
                                 full_pil_images[frameId] = img
                                 x1, y1, x2, y2 = bboxUtils.box_to_display(box, sourceInfo["PAR"])
                                 imgBuf = oiio.ImageBuf(img)
                                 imgBuf = oiio.ImageBufAlgo.crop(imgBuf, roi=oiio.ROI(x1, x2, y1, y2))
                                 img_crop = imgBuf.get_pixels(format=oiio.FLOAT)
-                                pil_images.append(Image.fromarray((255.0*img_crop).astype("uint8")))
-    
+                                pil_images.append(Image.fromarray((255.0 * img_crop).astype("uint8")))
+
                         if not rough_mask_available:
                             response = video_predictor.handle_request(
                                 request=dict(
@@ -503,12 +506,14 @@ Bounding box metadata is embedded under the `Meshroom:mrSegmentation:` namespace
 
                                 if chunk.node.enableTiling.value:
                                     if frame_idx not in full_rough_mask_images and rough_mask_available:
-                                        if os.path.isfile(str(chunk_image_paths[frame_idx - firstFrameId][8])):
-                                            logger.info(f"read mask for frame {frame_idx} at {chunk_image_paths[frame_idx - firstFrameId][8]}")
-                                            maskImg, h_mask, w_mask, PAR_mask, or_mask = image.loadImage(str(chunk_image_paths[frame_idx - firstFrameId][8]), True)
+                                        idx = frame_idx - firstFrameId
+                                        if os.path.isfile(str(chunk_image_paths[idx][8])):
+                                            logger.info(f"read mask for frame {frame_idx} at {chunk_image_paths[idx][8]}")
+                                            maskImg, _, _, _, _ = image.loadImage(str(chunk_image_paths[idx][8]), True)
                                             imgBuf = oiio.ImageBuf(maskImg)
                                             imgBuf = oiio.ImageBufAlgo.crop(imgBuf, roi=oiio.ROI(x1, x2, y1, y2))
-                                            full_rough_mask_images[frame_idx] = np.zeros((maskImg.shape[0], maskImg.shape[1], 1), np.float32)
+                                            full_rough_mask_images[frame_idx] = np.zeros((maskImg.shape[0], maskImg.shape[1], 1),
+                                                                                         np.float32)
                                             full_rough_mask_images[frame_idx][y1:y2, x1:x2, :] = imgBuf.get_pixels(format=oiio.FLOAT)[:, :, 0:1]
 
                                     if frame_idx in full_rough_mask_images:
@@ -529,7 +534,8 @@ Bounding box metadata is embedded under the `Meshroom:mrSegmentation:` namespace
 
                                         logger.debug(f"IoU = {IoU}")
                                         if IoU < chunk.node.minIoU.value:
-                                            logger.info(f"frame_idx = {frame_idx}; Tile = {tile_idx}; IoU = {IoU} => Use rough mask for this tile")
+                                            logger.info(f"frame_idx = {frame_idx}; Tile = {tile_idx}; IoU = {IoU}"
+                                                         " => Use rough mask for this tile")
                                             fine_mask = rough_mask_crop
 
                                         if rough_mask_available:
@@ -540,10 +546,10 @@ Bounding box metadata is embedded under the `Meshroom:mrSegmentation:` namespace
                                 final_mask = np.logical_or(fine_mask[:, :, 0], existing_mask)
                                 full_mask_images[frame_idx][y1:y2, x1:x2, 0:1] = np.dstack([final_mask])
                                 if chunk.node.verboseLevel.value.upper() == "DEBUG" and chunk.node.drawTilesInDebug.value:
-                                    full_mask_images[frame_idx][y1:y2, x1:x1+1, 1:3] = [255, 255]
-                                    full_mask_images[frame_idx][y1:y2, x2:x2+1, 1:3] = [255, 255]
-                                    full_mask_images[frame_idx][y1:y1+1, x1:x2, 1:3] = [255, 255]
-                                    full_mask_images[frame_idx][y2:y2+1, x1:x2, 1:3] = [255, 255]
+                                    full_mask_images[frame_idx][y1:y2, x1:x1 + 1, 1:3] = [255, 255]
+                                    full_mask_images[frame_idx][y1:y2, x2:x2 + 1, 1:3] = [255, 255]
+                                    full_mask_images[frame_idx][y1:y1 + 1, x1:x2, 1:3] = [255, 255]
+                                    full_mask_images[frame_idx][y2:y2 + 1, x1:x2, 1:3] = [255, 255]
 
                         video_predictor.handle_request(request=dict(type="close_session", session_id=session_id))
 
@@ -570,14 +576,16 @@ Bounding box metadata is embedded under the `Meshroom:mrSegmentation:` namespace
                     mask = np.zeros_like(full_mask_images[image_path[2]])
                     mask[m[:, :, 0]] = [1.0, 1.0, 1.0] if maskNbChannel == 3 else [1.0]
                 if chunk.node.verboseLevel.value.upper() == "DEBUG" and chunk.node.drawTilesInDebug.value:
-                    g = full_mask_images[image_path[2]][:,:,1:2] > 0
+                    g = full_mask_images[image_path[2]][:, :, 1:2] > 0
                     mask[g[:, :, 0]] = [1.0, 0, 0]
                 logger.info(f"frameId: {frameId} - {image_path[0]}")
 
                 if chunk.node.keepFilename.value:
-                    outputFileMask = os.path.join(chunk.node.output.value, Path(image_path[0]).stem + "." + chunk.node.extensionOut.value)
+                    outputFileMask = os.path.join(chunk.node.output.value, Path(image_path[0]).stem + "." +
+                                                  chunk.node.extensionOut.value)
                 else:
-                    outputFileMask = os.path.join(chunk.node.output.value, str(image_path[1]) + "." + chunk.node.extensionOut.value)
+                    outputFileMask = os.path.join(chunk.node.output.value, str(image_path[1]) + "." +
+                                                  chunk.node.extensionOut.value)
 
                 optWrite = avimg.ImageWriteOptions()
                 optWrite.toColorSpace(avimg.EImageColorSpace_NO_CONVERSION)
@@ -588,7 +596,7 @@ Bounding box metadata is embedded under the `Meshroom:mrSegmentation:` namespace
                 frame_metadata_deep_model = dict(metadata_deep_model)
                 for prompt, bboxes in metadata_boxes[firstFrameId + frameId].items():
                     for k, box in metadata_boxes[firstFrameId + frameId][prompt].items():
-                            frame_metadata_deep_model["Meshroom:mrSegmentation:" + k] = box
+                        frame_metadata_deep_model["Meshroom:mrSegmentation:" + k] = box
 
                 image.writeImage(outputFileMask, mask, sourceInfo["h_ori"], sourceInfo["w_ori"], sourceInfo["orientation"],
                                  sourceInfo["PAR"], frame_metadata_deep_model, optWrite)
@@ -600,7 +608,6 @@ Bounding box metadata is embedded under the `Meshroom:mrSegmentation:` namespace
 def get_image_paths_list(input_path, path_folder_x2 = "", path_folder_x4 = "", mask_folder = ""):
     from pyalicevision import sfmData, camera
     from pyalicevision import sfmDataIO
-    from pathlib import Path
 
     image_paths = []
 
@@ -610,7 +617,7 @@ def get_image_paths_list(input_path, path_folder_x2 = "", path_folder_x4 = "", m
             if sfmDataIO.load(dataAV, input_path, sfmDataIO.ALL):
                 views = dataAV.getViews()
                 commonParams = None
-                for id, v in views.items():
+                for vId, v in views.items():
                     image_x1_path = Path(v.getImage().getImagePath())
                     image_x1_name = image_x1_path.name
                     image_x2_path = None
@@ -627,12 +634,13 @@ def get_image_paths_list(input_path, path_folder_x2 = "", path_folder_x4 = "", m
                     par = 1.0
                     if pinhole is not None:
                         par = pinhole.getPixelAspectRatio()
-                    params = [v.getImage().getWidth(), v.getImage().getHeight(), par, image_x2_path is None, image_x4_path is None]
+                    params = [v.getImage().getWidth(), v.getImage().getHeight(), par,
+                              image_x2_path is None, image_x4_path is None]
                     if commonParams is None:
                         commonParams = params
                     if commonParams != params:
                         raise ValueError(f"All images do not have same dimensions or one image is missing its upscaled version: {params} vs {commonParams}")
-                    image_paths.append((image_x1_path, str(id), v.getFrameId(), v.getImage().getWidth(),
+                    image_paths.append((image_x1_path, str(vId), v.getFrameId(), v.getImage().getWidth(),
                                         v.getImage().getHeight(), par, image_x2_path, image_x4_path, mask_path))
 
             image_paths.sort(key=lambda x: x[0])

--- a/meshroom/sam3/VideoSegmentationSam3Boxes.py
+++ b/meshroom/sam3/VideoSegmentationSam3Boxes.py
@@ -1,4 +1,4 @@
-__version__ = "4.0"
+__version__ = "5.0"
 
 import os
 from pathlib import Path
@@ -11,12 +11,7 @@ import logging
 logger = logging.getLogger("VideoSegmentationSam3Boxes")
 
 class VideoSegmentationSam3Boxes(desc.Node):
-    size = avpar.DynamicViewsSize("input")
-    gpu = lambda node: desc.Level.EXTREME if node.useOnlyHighPowerGpu.value else desc.Level.INTENSIVE
-    # _cuda_tag = "cuda24G"
-
-    category = "Segmentation"
-    documentation = """
+    """
 ## Video Segmentation with SAM3 Bounding Boxes
 
 Generates binary segmentation masks for video sequences using **SAM3** (Segment Anything Model 3),
@@ -96,6 +91,11 @@ In debug mode with tile drawing enabled, masks are written as 3-channels with re
 Filenames use the original input name or the view ID depending on **Keep Filename**.
 Bounding box metadata is embedded under the `Meshroom:mrSegmentation:` namespace.
 """
+    size = avpar.DynamicViewsSize("input")
+    gpu = lambda node: desc.Level.EXTREME if node.useOnlyHighPowerGpu.value else desc.Level.INTENSIVE
+    # _cuda_tag = "cuda24G"
+
+    category = "Segmentation"
 
     inputs = [
         desc.File(

--- a/meshroom/sam3/VideoSegmentationSam3Text.py
+++ b/meshroom/sam3/VideoSegmentationSam3Text.py
@@ -1,4 +1,4 @@
-__version__ = "1.2"
+__version__ = "2.0"
 
 import copy
 import logging

--- a/meshroom/sam3/VideoSegmentationSam3Text.py
+++ b/meshroom/sam3/VideoSegmentationSam3Text.py
@@ -14,8 +14,8 @@ logger = logging.getLogger("VideoSegmentationSam3Text")
 
 class VideoSegmentationSam3Text(desc.Node):
     """
-Based on the Segment Anything video predictor model 3, the node generates a binary mask, a colored mask and an exr cryptomatte
-from a text prompt.
+Based on the Segment Anything video predictor model 3, the node generates a binary mask, a colored mask and an exr
+cryptomatte from a text prompt.
 """
     size = avpar.DynamicViewsSize("input")
     gpu = lambda node: desc.Level.EXTREME if node.useOnlyHighPowerGpu.value else desc.Level.INTENSIVE
@@ -52,8 +52,8 @@ from a text prompt.
         desc.BoolParam(
             name="timeSlicing",
             description="Enable time slicing by adding text prompt every N frames and Propagating the masks over N frames.\n"
-                        "Propagation is forward only by default, or both forward and backward when 'Combine Forward and Backward Segmentation'\n"
-                        "is enabled.",
+                        "Propagation is forward only by default, or both forward and backward when 'Combine Forward \n"
+                        "and Backward Segmentation' is enabled.",
             value=False,
         ),
         desc.IntParam(
@@ -79,7 +79,8 @@ from a text prompt.
         desc.BoolParam(
             name="maskInvert",
             label="Invert Masks",
-            description="Invert mask values. If selected, the pixels corresponding to the mask will be set to 0 instead of 255.",
+            description="Invert mask values.\n"
+                        "If selected, the pixels corresponding to the mask will be set to 0 instead of 255.",
             value=False,
         ),
         desc.BoolParam(
@@ -138,7 +139,8 @@ from a text prompt.
         desc.File(
             name="colorMasksFwd",
             label="Colored Masks Forward",
-            description="Colored segmentation masks resulting from forward propagation. Colors correspond to instance indexes.",
+            description="Colored segmentation masks resulting from forward propagation.\n"
+                        "Colors correspond to instance indexes.",
             semantic="image",
             value=None,
             enabled=lambda node: node.outputColorMasks.value,
@@ -146,7 +148,8 @@ from a text prompt.
         desc.File(
             name="colorMasksBwd",
             label="Colored Masks Backward",
-            description="Colored segmentation masks resulting from backward propagation. Colors correspond to instance indexes.",
+            description="Colored segmentation masks resulting from backward propagation.\n"
+                        "Colors correspond to instance indexes.",
             semantic="image",
             value=None,
             enabled=lambda node: node.outputColorMasks.value and node.combineFwdAndBwdSeg.value,
@@ -154,7 +157,8 @@ from a text prompt.
         desc.File(
             name="colorMasksMerged",
             label="Colored Masks Merged",
-            description="Colored segmentation masks resulting from merging forward and backward propagation. Colors correspond to instance indexes.",
+            description="Colored segmentation masks resulting from merging forward and backward propagation.\n"
+                        "Colors correspond to instance indexes.",
             semantic="image",
             value=None,
             enabled=lambda node: node.outputColorMasks.value and node.combineFwdAndBwdSeg.value,

--- a/meshroom/sam3/VideoSegmentationSam3Text.py
+++ b/meshroom/sam3/VideoSegmentationSam3Text.py
@@ -73,6 +73,7 @@ from a text prompt.
             label="Bonding Kernel Size",
             description="Kernel size for morphological processing applied for masks bonding.",
             value=11,
+            range=(1, 255, 2),
             enabled=lambda node: node.enableBonding.value,
         ),
         desc.BoolParam(

--- a/meshroom/sam3/VideoSegmentationSam3Text.py
+++ b/meshroom/sam3/VideoSegmentationSam3Text.py
@@ -63,6 +63,19 @@ from a text prompt.
             enabled=lambda node: node.timeSlicing.value,
         ),
         desc.BoolParam(
+            name="enableBonding",
+            label="Enable Masks Bonding",
+            description="Enable bonding where instances overlap.",
+            value=True,
+        ),
+        desc.IntParam(
+            name="bondingKernelSize",
+            label="Bonding Kernel Size",
+            description="Kernel size for morphological processing applied for masks bonding.",
+            value=11,
+            enabled=lambda node: node.enableBonding.value,
+        ),
+        desc.BoolParam(
             name="maskInvert",
             label="Invert Masks",
             description="Invert mask values. If selected, the pixels corresponding to the mask will be set to 0 instead of 255.",
@@ -298,8 +311,10 @@ from a text prompt.
             # Get detections for current frame (if any)
             frame_detections = direction_results.get(frame_id, {})
 
+            masks = []
             for key, mask_box_prob in frame_detections.items():
                 mask = mask_box_prob["mask"]
+                masks.append(mask.squeeze())
 
                 # Write binary mask corresponding to the definitive pass (forward if no merging, merged otherwise)
                 if is_definitive:
@@ -325,6 +340,16 @@ from a text prompt.
                 x1, y1, x2, y2 = bbox
                 bbox_str = f"{x1};{y1};{x2};{y2}"
                 metadata_boxes[frame_id][text_prompt][direction_name][f"{dir_prefix}_{text_prompt}_{key}"] = bbox_str
+
+            if masks:
+                masks_stack = np.stack(masks, axis=0)
+                mask_global = np.expand_dims(np.sum(masks_stack, axis=0), axis=-1)
+                if len(masks) > 1 and node.enableBonding.value:
+                    ks = node.bondingKernelSize.value
+                    mask_global = np.expand_dims(sam3Utils.bond_masks(masks, ks, ks, ks), axis=-1)
+                if is_definitive:
+                    mask_images[frame_id] = mask_global
+
 
             # Save color mask image
             if node.outputColorMasks.value:

--- a/segmentationRDS/sam3Utils.py
+++ b/segmentationRDS/sam3Utils.py
@@ -392,3 +392,31 @@ def merge_tracks(
     chunk_merged.clear()
 
     return global_chunk, new_overlap_frame, next_global_id
+
+
+def bond_masks(masks, dilate_kernel_size: int = 11, conflict_kernel_size: int = 11, close_kernel_size: int = 11):
+    import cv2
+
+    # Dilate each individual mask
+    kernel_dilate = cv2.getStructuringElement(cv2.MORPH_ELLIPSE, (dilate_kernel_size, dilate_kernel_size))
+    dilated_masks = [cv2.dilate(np.round(m).astype(np.uint8), kernel_dilate) for m in masks]
+    dilated_stack = np.stack(dilated_masks, axis=0)
+
+    # Detect overlapping regions to generate the activation mask
+    overlap_map = np.sum(dilated_stack, axis=0)
+    conflict_zone = (overlap_map >= 2).astype(np.uint8) * 255
+    kernel_conflict = cv2.getStructuringElement(cv2.MORPH_ELLIPSE, (conflict_kernel_size, conflict_kernel_size))
+    action_mask = cv2.dilate(conflict_zone, kernel_conflict)
+
+    # Merge individual masks into a single global mask
+    masks_stack = np.stack(masks, axis=0)
+    global_mask_raw = (np.sum(masks_stack, axis=0) > 0).astype(np.uint8) * 255 
+
+    # Apply morphological closing to fill holes in the global mask
+    kernel_close = cv2.getStructuringElement(cv2.MORPH_ELLIPSE, (close_kernel_size, close_kernel_size))
+    global_mask_closed = cv2.morphologyEx(global_mask_raw, cv2.MORPH_CLOSE, kernel_close)
+
+    # Apply the closed mask only within detected conflict regions
+    bonded_mask = np.where(action_mask > 0, global_mask_closed, global_mask_raw)
+
+    return bonded_mask


### PR DESCRIPTION
This pull request introduces a new "masks bonding" feature to the SAM3 image and video segmentation nodes in Meshroom, allowing overlapping instance masks to be merged using morphological operations. The change is configurable via new parameters and is implemented consistently across all relevant segmentation nodes and processing pipelines.

**Feature: Masks Bonding for Overlapping Instances**

* Added new parameters `enableBonding` (bool) and `bondingKernelSize` (int) to the following nodes: `ImageSegmentationSam3`, `VideoSegmentationSam3`, `VideoSegmentationSam3Text`, and `VideoSegmentationSam3Boxes`, enabling users to control bonding behavior and kernel size for morphological processing.

**Implementation: Mask Bonding Logic**

* Introduced a new utility function `bond_masks` in `sam3Utils.py` that performs dilation, conflict region detection, and morphological closing to merge overlapping masks, controlled by kernel size parameters.

**Integration: Processing Pipeline Updates**

* Updated mask processing logic in all relevant `processChunk` methods to use the new bonding feature: when enabled and multiple masks are present, masks are merged using the bonding kernel size. This affects both forward and backward propagation in video segmentation, as well as tiling and text-prompted segmentation.


These changes collectively provide more robust control over how overlapping segmentation masks are handled, improving the quality of mask outputs in scenarios with touching or overlapping objects.