### PR TITLE
Merge Forward and Backward tracking in VideoSegmentationSam3Text

### DIFF
--- a/meshroom/rotoPersons.mg
+++ b/meshroom/rotoPersons.mg
@@ -7,7 +7,7 @@
             "CopyFiles": "1.3",
             "ViTMatte": "1.0",
             "VideoSegmentationSam3Boxes": "4.0",
-            "VideoSegmentationSam3Text": "1.1"
+            "VideoSegmentationSam3Text": "1.2"
         },
         "template": true
     },

--- a/meshroom/sam3/VideoSegmentationSam3Text.py
+++ b/meshroom/sam3/VideoSegmentationSam3Text.py
@@ -522,17 +522,16 @@ from a text prompt.
 def get_image_paths_list(input_path):
     from pyalicevision import sfmData
     from pyalicevision import sfmDataIO
-    from pathlib import Path
 
     image_paths = []
 
     if Path(input_path).suffix.lower() in [".sfm", ".abc"]:
         if Path(input_path).exists():
-            dataAV = sfmData.SfMData()
-            if sfmDataIO.load(dataAV, input_path, sfmDataIO.ALL):
-                views = dataAV.getViews()
-                for id, v in views.items():
-                   image_paths.append((Path(v.getImage().getImagePath()), str(id), v.getFrameId()))
+            data = sfmData.SfMData()
+            if sfmDataIO.load(data, input_path, sfmDataIO.ALL):
+                views = data.getViews()
+                for view_id, view in views.items():
+                    image_paths.append((Path(view.getImage().getImagePath()), str(view_id), view.getFrameId()))
 
             image_paths.sort(key=lambda x: x[0])
     else:

--- a/meshroom/sam3/VideoSegmentationSam3Text.py
+++ b/meshroom/sam3/VideoSegmentationSam3Text.py
@@ -1,4 +1,4 @@
-__version__ = "1.1"
+__version__ = "1.2"
 
 import os
 from pathlib import Path
@@ -23,13 +23,11 @@ from a text prompt.
     inputs = [
         desc.File(
             name="input",
-            label="Input",
             description="SfMData file.",
             value="",
         ),
         desc.StringParam(
             name="prompt",
-            label="Prompt",
             description="What to segment, one item per line.",
             value="person",
             semantic="multiline",
@@ -48,7 +46,6 @@ from a text prompt.
         ),
         desc.BoolParam(
             name="timeSlicing",
-            label="Time Slicing",
             description="Enable time slicing by adding text prompt every N frames and Propagating the masks over N frames.\n"
                         "Propagation is forward only by default, or both forward and backward when 'Combine Forward and Backward Segmentation'\n"
                         "is enabled.",
@@ -56,7 +53,6 @@ from a text prompt.
         ),
         desc.IntParam(
             name="sliceSize",
-            label="Slice Size",
             description="Number of frames on which the mask is propagated.",
             value=16,
             enabled=lambda node: node.timeSlicing.value,
@@ -69,13 +65,11 @@ from a text prompt.
         ),
         desc.BoolParam(
             name="outputCryptomatte",
-            label="Output Cryptomatte",
             description="Generate exr images containing cryptomatte to encode the segmentation results.",
             value=False,
         ),
         desc.BoolParam(
             name="outputColorMasks",
-            label="Output Color Masks",
             description="Generate colored masks where colors are linked with object Ids.",
             value=False,
         ),
@@ -88,7 +82,6 @@ from a text prompt.
         ),
         desc.BoolParam(
             name="keepFilename",
-            label="Keep Filename",
             description="Keep the filename of the inputs for the outputs.",
             value=True,
         ),
@@ -103,7 +96,6 @@ from a text prompt.
         ),
         desc.ChoiceParam(
             name="verboseLevel",
-            label="Verbose Level",
             description="Verbosity level (fatal, error, warning, info, debug).",
             value="info",
             values=VERBOSE_LEVEL,
@@ -120,7 +112,6 @@ from a text prompt.
         ),
         desc.File(
             name="masks",
-            label="Masks",
             description="Generated segmentation masks.",
             semantic="image",
             value=lambda attr: "{nodeCacheFolder}/" + ("<FILESTEM>" if attr.node.keepFilename.value else "<VIEW_ID>") + "." + attr.node.extensionOut.value,
@@ -152,7 +143,7 @@ from a text prompt.
         desc.File(
             name="cryptomatteFwd",
             label="Cryptomatte Forward",
-            description="Cryptomatte resulting from forward propagation embedded in exr images.",
+            description="Cryptomatte resulting from forward propagation embedded in EXR images.",
             semantic="image",
             value=None,
             enabled=lambda node: node.outputCryptomatte.value,
@@ -160,7 +151,7 @@ from a text prompt.
         desc.File(
             name="cryptomatteBwd",
             label="Cryptomatte Backward",
-            description="Cryptomatte resulting from backward propagation embedded in exr images.",
+            description="Cryptomatte resulting from backward propagation embedded in EXR images.",
             semantic="image",
             value=None,
             enabled=lambda node: node.outputCryptomatte.value and node.combineFwdAndBwdSeg.value,
@@ -245,7 +236,7 @@ from a text prompt.
 
             for idx, path in enumerate(chunk_image_paths):
                 img, h_ori, w_ori, PAR, orientation = image.loadImage(str(chunk_image_paths[idx][0]), True)
-                pil_images.append(Image.fromarray((255.0*img).astype("uint8")))
+                pil_images.append(Image.fromarray((255.0 * img).astype("uint8")))
                 sourceInfo = {"h_ori": h_ori, "w_ori": w_ori, "PAR": PAR, "orientation": orientation}
                 mask_images.append(np.zeros_like(img))
 
@@ -343,16 +334,17 @@ from a text prompt.
                             colorPalette.generate_palette(next_global_id_bwd + 1)
                             logger.info(f"next_global_id_bwd = {next_global_id_bwd}")
 
-                            track_fwd = sam3Utils.prepareMasksForVisualization(outputs_per_frame[frameIdxToTextPrompt[n - 1]])
-                            track_bwd = sam3Utils.prepareMasksForVisualization(outputs_per_frame[fIdx])
+                            # Create FRESH copies for merge_tracks since the previous calls cleared the dicts
+                            track_fwd_for_merge = sam3Utils.prepareMasksForVisualization(outputs_per_frame[frameIdxToTextPrompt[n - 1]])
+                            track_bwd_for_merge = sam3Utils.prepareMasksForVisualization(outputs_per_frame[fIdx])
                             firstFrame = frameIdxToTextPrompt[n - 1]
                             lastFrame = fIdx
-                            fwd = {k: v for k,v in track_fwd.items() if k >= firstFrame and k <= lastFrame}
-                            bwd = {k: v for k,v in track_bwd.items() if k >= firstFrame and k <= lastFrame}
+                            fwd_for_merge = {k: v for k,v in track_fwd_for_merge.items() if k >= firstFrame and k <= lastFrame}
+                            bwd_for_merge = {k: v for k,v in track_bwd_for_merge.items() if k >= firstFrame and k <= lastFrame}
 
                             fwd_bwd, prev_overlap_detections_merged, next_global_id_merged = sam3Utils.merge_tracks(
-                                fwd_results=fwd,
-                                bwd_results=bwd,
+                                fwd_results=fwd_for_merge,
+                                bwd_results=bwd_for_merge,
                                 prev_overlap_detections=prev_overlap_detections_merged,
                                 next_global_id=next_global_id_merged,
                                 similatity_threshold_merge=0.3,
@@ -380,7 +372,7 @@ from a text prompt.
                             mask = maskBoxProb["mask"]
                             mask_images[frameId][mask] = [(int(key) + 1) * 255, 255, 255]
                             color = colorPalette.at(int(key)) if colorPalette.at(int(key)) is not None else [255, 255, 255]
-                            colorMaskImageFwd[mask] = [x/255.0 for x in color]
+                            colorMaskImageFwd[mask] = [x / 255.0 for x in color]
 
                             if chunk.node.outputCryptomatte.value:
                                 obj_name = f"{cryptoName}_fwd_{int(key)}"
@@ -429,7 +421,7 @@ from a text prompt.
                                 mask = maskBoxProb["mask"]
                                 mask_images[frameId][mask] = [(int(key) + 1) * 255, 255, 255]
                                 color = colorPalette.at(int(key)) if colorPalette.at(int(key)) is not None else [255, 255, 255]
-                                colorMaskImageBwd[mask] = [x/255.0 for x in color]
+                                colorMaskImageBwd[mask] = [x / 255.0 for x in color]
                                 if chunk.node.outputCryptomatte.value:
                                     obj_name = f"{cryptoName}_bwd_{int(key)}"
                                     f32_hash, hex_val, _ = image.hash_name(obj_name)
@@ -439,8 +431,8 @@ from a text prompt.
                                 bbox = sam3Utils.xywhNorm2xyxy(maskBoxProb["box_xywh"], sourceInfo["w_ori"], sourceInfo["h_ori"]) # (x, y, x+w, y+h)
                                 boxes[textPrompt]["backward"][firstFrameId + frameId][key] = bbox
                                 x1,y1,x2,y2 = bbox
-                                bbox_str = str(x1)+";"+str(y1)+";"+str(x2)+";"+str(y2)
-                                metadata_boxes[frameId][textPrompt]["backward"]["bwd_"+textPrompt+"_"+str(key)] = bbox_str
+                                bbox_str = str(x1) + ";" + str(y1) + ";" + str(x2) + ";" + str(y2)
+                                metadata_boxes[frameId][textPrompt]["backward"]["bwd_" + textPrompt + "_" + str(key)] = bbox_str
 
                             if chunk.node.outputColorMasks.value:
                                 if chunk.node.keepFilename.value:
@@ -469,13 +461,13 @@ from a text prompt.
                                     mask = maskBoxProb["mask"]
                                     mask_images[frameId][mask] = [(int(key) + 1) * 255, 255, 255]
                                     color = colorPalette.at(int(key)) if colorPalette.at(int(key)) is not None else [255, 255, 255]
-                                    colorMaskImageMerged[mask] = [x/255.0 for x in color]
+                                    colorMaskImageMerged[mask] = [x / 255.0 for x in color]
                                     
                                     bbox = sam3Utils.xywhNorm2xyxy(maskBoxProb["box_xywh"], sourceInfo["w_ori"], sourceInfo["h_ori"]) # (x, y, x+w, y+h)
                                     boxes[textPrompt]["merged"][firstFrameId + frameId][key] = bbox
                                     x1,y1,x2,y2 = bbox
-                                    bbox_str = str(x1)+";"+str(y1)+";"+str(x2)+";"+str(y2)
-                                    metadata_boxes[frameId][textPrompt]["merged"]["merged_"+textPrompt+"_"+str(key)] = bbox_str
+                                    bbox_str = str(x1) + ";" + str(y1) + ";" + str(x2) + ";" + str(y2)
+                                    metadata_boxes[frameId][textPrompt]["merged"]["merged_" + textPrompt + "_" + str(key)] = bbox_str
 
                                 if chunk.node.outputColorMasks.value:
                                     if chunk.node.keepFilename.value:

--- a/meshroom/sam3/VideoSegmentationSam3Text.py
+++ b/meshroom/sam3/VideoSegmentationSam3Text.py
@@ -178,8 +178,8 @@ from a text prompt.
         node.colorMasksFwd.value = color_mask_prefix + "_fwd_" + src_filename + ".exr"
         node.colorMasksBwd.value = color_mask_prefix + "_bwd_" + src_filename + ".png"
         node.colorMasksMerged.value = color_mask_prefix + "_merged_" + src_filename + ".exr"
-        node.cryptomatteFwd.value = cryptomatte_prefix + "_fwd_" + src_filename + ".png"
-        node.cryptomatteBwd.value = cryptomatte_prefix + "_bwd_" + src_filename + ".png"
+        node.cryptomatteFwd.value = cryptomatte_prefix + "_fwd_" + src_filename + ".exr"
+        node.cryptomatteBwd.value = cryptomatte_prefix + "_bwd_" + src_filename + ".exr"
 
 
     def processChunk(self, chunk):

--- a/meshroom/sam3/VideoSegmentationSam3Text.py
+++ b/meshroom/sam3/VideoSegmentationSam3Text.py
@@ -244,16 +244,13 @@ from a text prompt.
         color_palette,
         source_info,
         state,
-        metadata_deep_model,
-        color_mask_ext,          # ".exr" or ".png"
-        write_cryptomatte=False
+        metadata_deep_model
     ):
         """ Helper to process results, draw color masks, generate cryptomatte, and save outputs. """
         from pyalicevision import image as avimg
         from segmentationRDS import image, sam3Utils
         import numpy as np
 
-        # Explicitly map direction names to exact legacy prefixes
         prefix_map = {
             "forward": "fwd",
             "backward": "bwd",
@@ -261,11 +258,21 @@ from a text prompt.
         }
         dir_prefix = prefix_map[direction_name]
 
+        ext_map = {
+            "forward": ".exr",
+            "backward": ".png",
+            "merged": ".exr"
+        }
+        color_mask_ext = ext_map[direction_name]
+
         first_frame_id = source_info["first_frame_id"]
-        crypto_name = "object" if text_prompt == "" else text_prompt
+
         mask_images = state["mask_images"]
         boxes = state["boxes"]
         metadata_boxes = state["metadata_boxes"]
+
+        write_cryptomatte = (direction_name in ["forward", "backward"])
+        crypto_name = "object" if text_prompt == "" else text_prompt
 
         for frame_id in frame_range:
             color_mask_image = np.zeros(source_info["shape"], dtype=source_info["dtype"])
@@ -340,6 +347,90 @@ from a text prompt.
                     crypto_cov
                 )
 
+    def _update_tracking_at_step(
+        self,
+        n,
+        frame_idx,
+        frame_idx_to_text_prompt,
+        outputs_per_frame,
+        track_states,
+        color_palette,
+        combine_fwd_bwd
+    ):
+        """ Helper to process and slice forward/backward tracks and update global IDs. """
+        from segmentationRDS import sam3Utils
+
+        # n == 0: Initialization block
+        if n == 0:
+            fwd_only = sam3Utils.prepareMasksForVisualization(outputs_per_frame[frame_idx])
+            bwd_only = sam3Utils.prepareMasksForVisualization(outputs_per_frame[frame_idx])
+            fwd_bwd = None
+
+            # Initialize backward tracking
+            bwd_frame0_only = {frame_idx: bwd_only[frame_idx]}
+            _, track_states["bwd"]["prev_overlap"], track_states["bwd"]["next_id"] = self._update_global_ids(
+                bwd_frame0_only, track_states["bwd"]["prev_overlap"], track_states["bwd"]["next_id"], color_palette
+            )
+            logger.info(f"next_global_id_bwd = {track_states['bwd']['next_id']}")
+
+            # Initialize merged tracking if enabled
+            if combine_fwd_bwd:
+                merged_frame0_only = {frame_idx: fwd_only[frame_idx]}
+                fwd_bwd, track_states["merged"]["prev_overlap"], track_states["merged"]["next_id"] = self._update_global_ids(
+                    merged_frame0_only, track_states["merged"]["prev_overlap"], track_states["merged"]["next_id"], color_palette
+                )
+                logger.info(f"next_global_id_merged = {track_states['merged']['next_id']}")
+
+            return fwd_only, bwd_only, fwd_bwd
+
+        # n > 0: Propagation & Merging block
+        track_fwd = sam3Utils.prepareMasksForVisualization(outputs_per_frame[frame_idx])
+        first_frame = frame_idx
+        last_frame = frame_idx if n == len(frame_idx_to_text_prompt) - 1 else frame_idx_to_text_prompt[n + 1]
+        fwd = self._slice_track(track_fwd, first_frame, last_frame)
+
+        fwd_only, track_states["fwd"]["prev_overlap"], track_states["fwd"]["next_id"] = self._update_global_ids(
+            fwd, track_states["fwd"]["prev_overlap"], track_states["fwd"]["next_id"], color_palette
+        )
+        logger.info(f"next_global_id_fwd = {track_states['fwd']['next_id']}")
+
+        bwd_only = None
+        fwd_bwd = None
+
+        if combine_fwd_bwd:
+            track_bwd = sam3Utils.prepareMasksForVisualization(outputs_per_frame[frame_idx])
+            first_frame_bwd = frame_idx_to_text_prompt[n - 1]
+            last_frame_bwd = frame_idx
+            bwd = self._slice_track(track_bwd, first_frame_bwd, last_frame_bwd)
+
+            bwd_only, track_states["bwd"]["prev_overlap"], track_states["bwd"]["next_id"] = self._update_global_ids(
+                bwd, track_states["bwd"]["prev_overlap"], track_states["bwd"]["next_id"], color_palette
+            )
+            logger.info(f"next_global_id_bwd = {track_states['bwd']['next_id']}")
+
+            # Fresh slicing calculations for merge operations
+            track_fwd_for_merge = sam3Utils.prepareMasksForVisualization(outputs_per_frame[frame_idx_to_text_prompt[n - 1]])
+            track_bwd_for_merge = sam3Utils.prepareMasksForVisualization(outputs_per_frame[frame_idx])
+            fwd_for_merge = self._slice_track(track_fwd_for_merge, first_frame_bwd, last_frame_bwd)
+            bwd_for_merge = self._slice_track(track_bwd_for_merge, first_frame_bwd, last_frame_bwd)
+
+            fwd_bwd, track_states["merged"]["prev_overlap"], track_states["merged"]["next_id"] = sam3Utils.merge_tracks(
+                fwd_results=fwd_for_merge,
+                bwd_results=bwd_for_merge,
+                prev_overlap_detections=track_states["merged"]["prev_overlap"],
+                next_global_id=track_states["merged"]["next_id"],
+                similarity_threshold_merge=0.3,
+                similarity_threshold_track=0.4,
+                use_mask=True,
+            )
+            color_palette.generate_palette(track_states["merged"]["next_id"] + 1)
+            logger.info(f"next_global_id_merged = {track_states['merged']['next_id']}")
+
+        # Clear historical frames from memory
+        del outputs_per_frame[frame_idx_to_text_prompt[n - 1]]
+
+        return fwd_only, bwd_only, fwd_bwd
+
     def resolve_paths(self, node):
         import re
 
@@ -396,16 +487,11 @@ from a text prompt.
             metadata_deep_model["Meshroom:mrSegmentation:DeepModelName"] = "SegmentAnything"
             metadata_deep_model["Meshroom:mrSegmentation:DeepModelVersion"] = "sam3-Video-TextPrompt"
 
-            pil_images = []
-            mask_images = []
-
             color_palette = image.paletteGenerator()
             first_frame_id = self.image_paths[0][2]
             frame_number = len(self.image_paths)
 
-            frame_idx_to_text_prompt, max_frame_num_to_track, track_dir = self._get_tracking_config(
-                chunk.node, frame_number
-            )
+            frame_idx_to_text_prompt, max_frame_num_to_track, track_dir = self._get_tracking_config(chunk.node, frame_number)
             logger.info(f"frame_idx_to_text_prompt: {frame_idx_to_text_prompt}; direction = {track_dir}")
 
             pil_images, mask_images, source_info = self._load_source_images()
@@ -417,9 +503,7 @@ from a text prompt.
             session_id = response["session_id"]
 
             boxes = {}
-            metadata_boxes = {}
-            for frame_id in range(frame_number):
-                metadata_boxes[frame_id] = {}
+            metadata_boxes = {frame_id: {} for frame_id in range(frame_number)}
 
             tracking_state = {
                 "mask_images": mask_images,
@@ -440,15 +524,13 @@ from a text prompt.
 
                 outputs_per_frame = {}
 
-                prev_overlap_detections_fwd = {}
-                next_global_id_fwd: int = 0
-                prev_overlap_detections_bwd = {}
-                next_global_id_bwd: int = 0
-                prev_overlap_detections_merged = {}
-                next_global_id_merged: int = 0
+                track_states = {
+                    "fwd": {"prev_overlap": {}, "next_id": 0},
+                    "bwd": {"prev_overlap": {}, "next_id": 0},
+                    "merged": {"prev_overlap": {}, "next_id": 0}
+                }
 
                 for n, frame_idx in enumerate(frame_idx_to_text_prompt):
-
                     logger.info(f"text prompt at relative frame {frame_idx} (absolute frame {int(first_frame_id) + frame_idx})")
 
                     video_predictor.handle_request(
@@ -461,70 +543,15 @@ from a text prompt.
                     )
                     outputs_per_frame[frame_idx] = sam3Utils.propagateInVideo(video_predictor, session_id, frame_idx, max_frame_num_to_track, track_dir)
 
-                    if n == 0:
-                        fwd_only = sam3Utils.prepareMasksForVisualization(outputs_per_frame[frame_idx])
-                        bwd_only = sam3Utils.prepareMasksForVisualization(outputs_per_frame[frame_idx])
-
-                        # Initialize prev_overlap_detections_bwd with global IDs
-                        # by running a trivial assign_global_ids on just frame 0
-                        bwd_frame0_only = {frame_idx: bwd_only[frame_idx]}
-                        _, prev_overlap_detections_bwd, next_global_id_bwd = self._update_global_ids(
-                            bwd_frame0_only, {}, next_global_id_bwd, color_palette
-                        )
-                        logger.info(f"next_global_id_bwd = {next_global_id_bwd}")
-
-                        # Initialize merged tracking for n == 0 as well
-                        if chunk.node.combineFwdAndBwdSeg.value:
-                            merged_frame0_only = {frame_idx: fwd_only[frame_idx]}
-                            fwd_bwd, prev_overlap_detections_merged, next_global_id_merged = self._update_global_ids(
-                                merged_frame0_only, {}, next_global_id_merged, color_palette
-                            )
-                            logger.info(f"next_global_id_merged = {next_global_id_merged}")
-
-                    else:
-                        track_fwd = sam3Utils.prepareMasksForVisualization(outputs_per_frame[frame_idx])
-                        first_frame = frame_idx
-                        last_frame = frame_idx if n == len(frame_idx_to_text_prompt) - 1 else frame_idx_to_text_prompt[n + 1]
-                        fwd = self._slice_track(track_fwd, first_frame, last_frame)
-
-                        fwd_only, prev_overlap_detections_fwd, next_global_id_fwd = self._update_global_ids(
-                            fwd, prev_overlap_detections_fwd, next_global_id_fwd, color_palette
-                        )
-                        logger.info(f"next_global_id_fwd = {next_global_id_fwd}")
-
-                        if chunk.node.combineFwdAndBwdSeg.value:
-                            track_bwd = sam3Utils.prepareMasksForVisualization(outputs_per_frame[frame_idx])
-
-                            first_frame = frame_idx_to_text_prompt[n - 1]
-                            last_frame = frame_idx
-                            bwd = self._slice_track(track_bwd, first_frame, last_frame)
-
-                            bwd_only, prev_overlap_detections_bwd, next_global_id_bwd = self._update_global_ids(
-                                bwd, prev_overlap_detections_bwd, next_global_id_bwd, color_palette
-                            )
-                            logger.info(f"next_global_id_bwd = {next_global_id_bwd}")
-
-                            # Create FRESH copies for merge_tracks since the previous calls cleared the dicts
-                            track_fwd_for_merge = sam3Utils.prepareMasksForVisualization(outputs_per_frame[frame_idx_to_text_prompt[n - 1]])
-                            track_bwd_for_merge = sam3Utils.prepareMasksForVisualization(outputs_per_frame[frame_idx])
-                            first_frame = frame_idx_to_text_prompt[n - 1]
-                            last_frame = frame_idx
-                            fwd_for_merge = self._slice_track(track_fwd_for_merge, first_frame, last_frame)
-                            bwd_for_merge = self._slice_track(track_bwd_for_merge, first_frame, last_frame)
-
-                            fwd_bwd, prev_overlap_detections_merged, next_global_id_merged = sam3Utils.merge_tracks(
-                                fwd_results=fwd_for_merge,
-                                bwd_results=bwd_for_merge,
-                                prev_overlap_detections=prev_overlap_detections_merged,
-                                next_global_id=next_global_id_merged,
-                                similarity_threshold_merge=0.3,
-                                similarity_threshold_track=0.4,
-                                use_mask=True,
-                            )
-                            color_palette.generate_palette(next_global_id_merged + 1)
-                            logger.info(f"next_global_id_merged = {next_global_id_merged}")
-
-                        del outputs_per_frame[frame_idx_to_text_prompt[n - 1]]
+                    fwd_only, bwd_only, fwd_bwd = self._update_tracking_at_step(
+                        n=n,
+                        frame_idx=frame_idx,
+                        frame_idx_to_text_prompt=frame_idx_to_text_prompt,
+                        outputs_per_frame=outputs_per_frame,
+                        track_states=track_states,
+                        color_palette=color_palette,
+                        combine_fwd_bwd=chunk.node.combineFwdAndBwdSeg.value
+                    )
 
                     # write Fwd from frame_idx to frame_idx_to_text_prompt[n + 1]
                     last_frame_idx_fwd = frame_idx_to_text_prompt[n + 1] if n < len(frame_idx_to_text_prompt) - 1 else frame_number
@@ -540,9 +567,7 @@ from a text prompt.
                         color_palette=color_palette,
                         source_info=source_info,
                         state=tracking_state,
-                        metadata_deep_model=metadata_deep_model,
-                        color_mask_ext=".exr",
-                        write_cryptomatte=True
+                        metadata_deep_model=metadata_deep_model
                     )
 
                     if chunk.node.combineFwdAndBwdSeg.value:
@@ -558,9 +583,7 @@ from a text prompt.
                             color_palette=color_palette,
                             source_info=source_info,
                             state=tracking_state,
-                            metadata_deep_model=metadata_deep_model,
-                            color_mask_ext=".png",
-                            write_cryptomatte=True
+                            metadata_deep_model=metadata_deep_model
                         )
 
                         if n > 0:
@@ -573,9 +596,7 @@ from a text prompt.
                                 color_palette=color_palette,
                                 source_info=source_info,
                                 state=tracking_state,
-                                metadata_deep_model=metadata_deep_model,
-                                color_mask_ext=".exr",
-                                write_cryptomatte=False
+                                metadata_deep_model=metadata_deep_model
                             )
 
             prompts = [text_prompt.strip() for text_prompt in self.text_prompts if text_prompt.strip()]

--- a/meshroom/sam3/VideoSegmentationSam3Text.py
+++ b/meshroom/sam3/VideoSegmentationSam3Text.py
@@ -364,13 +364,27 @@ from a text prompt.
         combine_fwd_bwd
     ):
         """ Helper to process and slice forward/backward tracks and update global IDs. """
+        import copy
         from segmentationRDS import sam3Utils
+
+        # Call prepareMasksForVisualization once per raw outputs dictionary to prevent repeating mutating calls
+        prepared_track = sam3Utils.prepareMasksForVisualization(outputs_per_frame[frame_idx])
 
         # n == 0: Initialization block
         if n == 0:
-            fwd_only = sam3Utils.prepareMasksForVisualization(outputs_per_frame[frame_idx])
-            bwd_only = sam3Utils.prepareMasksForVisualization(outputs_per_frame[frame_idx])
+            # Deep copy to prevent in-place modifications from leaking between lists
+            fwd_only = copy.deepcopy(prepared_track)
+            bwd_only = copy.deepcopy(prepared_track)
             fwd_bwd = None
+
+            # Properly initialize the Forward global ID tracking at n = 0
+            first_frame = frame_idx
+            last_frame = frame_idx_to_text_prompt[1] if len(frame_idx_to_text_prompt) > 1 else max(fwd_only.keys())
+            fwd = self._slice_track(fwd_only, first_frame, last_frame)
+            fwd_only, track_states["fwd"]["prev_overlap"], track_states["fwd"]["next_id"] = self._update_global_ids(
+                fwd, track_states["fwd"]["prev_overlap"], track_states["fwd"]["next_id"], color_palette
+            )
+            logger.info(f"next_global_id_fwd = {track_states['fwd']['next_id']}")
 
             # Initialize backward tracking
             bwd_frame0_only = {frame_idx: bwd_only[frame_idx]}
@@ -392,7 +406,9 @@ from a text prompt.
         # n > 0: Propagation & Merging block
         track_fwd = sam3Utils.prepareMasksForVisualization(outputs_per_frame[frame_idx])
         first_frame = frame_idx
-        last_frame = frame_idx if n == len(frame_idx_to_text_prompt) - 1 else frame_idx_to_text_prompt[n + 1]
+
+        # Keep the remaining forward frames on the last segment instead of truncating to frame_idx
+        last_frame = max(track_fwd.keys()) if n == len(frame_idx_to_text_prompt) - 1 else frame_idx_to_text_prompt[n + 1]
         fwd = self._slice_track(track_fwd, first_frame, last_frame)
 
         fwd_only, track_states["fwd"]["prev_overlap"], track_states["fwd"]["next_id"] = self._update_global_ids(
@@ -414,9 +430,10 @@ from a text prompt.
             )
             logger.info(f"next_global_id_bwd = {track_states['bwd']['next_id']}")
 
-            # Fresh slicing calculations for merge operations
-            track_fwd_for_merge = sam3Utils.prepareMasksForVisualization(outputs_per_frame[frame_idx_to_text_prompt[n - 1]])
-            track_bwd_for_merge = sam3Utils.prepareMasksForVisualization(outputs_per_frame[frame_idx])
+            # Fresh, completely isolated slice calculations for merge operations
+            prev_prepared_track = sam3Utils.prepareMasksForVisualization(outputs_per_frame[frame_idx_to_text_prompt[n - 1]])
+            track_fwd_for_merge = copy.deepcopy(prev_prepared_track)
+            track_bwd_for_merge = copy.deepcopy(prepared_track)
             fwd_for_merge = self._slice_track(track_fwd_for_merge, first_frame_bwd, last_frame_bwd)
             bwd_for_merge = self._slice_track(track_bwd_for_merge, first_frame_bwd, last_frame_bwd)
 

--- a/meshroom/sam3/VideoSegmentationSam3Text.py
+++ b/meshroom/sam3/VideoSegmentationSam3Text.py
@@ -182,6 +182,58 @@ from a text prompt.
         color_palette.generate_palette(updated_id + 1)
         return updated_res, next_prev_overlap, updated_id
 
+    def _slice_track(self, track_data, start, end):
+        """ Helper to slice tracking dictionaries between frame bounds. """
+        return {k: v for k, v in track_data.items() if start <= k <= end}
+
+    def _get_tracking_config(self, node, frame_number):
+        """ Helper to determine frame steps and direction for tracking. """
+        frame_idx_to_text_prompt = [0]
+        max_frame_num_to_track = None
+        track_dir = "forward"
+
+        if node.timeSlicing.value:
+            max_frame_num_to_track = node.sliceSize.value
+            curr_frame_to_text_prompt = 0
+            while curr_frame_to_text_prompt + node.sliceSize.value < frame_number:
+                curr_frame_to_text_prompt += node.sliceSize.value
+                frame_idx_to_text_prompt.append(curr_frame_to_text_prompt)
+
+        if node.combineFwdAndBwdSeg.value:
+            track_dir = "both"
+            if frame_idx_to_text_prompt[-1] < frame_number - 1:
+                frame_idx_to_text_prompt.append(frame_number - 1)
+
+        return frame_idx_to_text_prompt, max_frame_num_to_track, track_dir
+
+    def _load_source_images(self, chunk_image_paths):
+        """ Helper to load input images, prepare PIL frames, and extract dimensions. """
+        from PIL import Image
+        from segmentationRDS import image
+        import numpy as np
+
+        pil_images = []
+        mask_images = []
+        source_info = None
+
+        for idx, path_data in enumerate(chunk_image_paths):
+            img, h_ori, w_ori, PAR, orientation = image.loadImage(str(path_data[0]), True)
+            pil_images.append(Image.fromarray((255.0 * img).astype("uint8")))
+
+            # Store source dimensions from the first image (assumed uniform)
+            if idx == 0:
+                source_info = {
+                    "h_ori": h_ori,
+                    "w_ori": w_ori,
+                    "PAR": PAR,
+                    "orientation": orientation,
+                    "shape": img.shape,
+                    "dtype": img.dtype
+                }
+            mask_images.append(np.zeros_like(img))
+
+        return pil_images, mask_images, source_info
+
     def resolve_paths(self, node):
         import re
 
@@ -206,7 +258,6 @@ from a text prompt.
         node.colorMasksMerged.value = color_mask_prefix + "_merged_" + src_filename + ".exr"
         node.cryptomatteFwd.value = cryptomatte_prefix + "_fwd_" + src_filename + ".exr"
         node.cryptomatteBwd.value = cryptomatte_prefix + "_bwd_" + src_filename + ".exr"
-
 
     def processChunk(self, chunk):
         from segmentationRDS import image, sam3Utils
@@ -250,38 +301,15 @@ from a text prompt.
             first_frame_id = chunk_image_paths[0][2]
             frame_number = len(chunk_image_paths)
 
-            frame_idx_to_text_prompt = [0]
-            max_frame_num_to_track = None
-            track_dir = "forward"
-            if chunk.node.timeSlicing.value:
-                max_frame_num_to_track = chunk.node.sliceSize.value
-                currFrameToTextPrompt = 0
-                while currFrameToTextPrompt + chunk.node.sliceSize.value < frame_number:
-                    currFrameToTextPrompt += chunk.node.sliceSize.value
-                    frame_idx_to_text_prompt.append(currFrameToTextPrompt)
-            if chunk.node.combineFwdAndBwdSeg.value:
-                track_dir = "both"
-                if frame_idx_to_text_prompt[-1] < frame_number - 1:
-                    frame_idx_to_text_prompt.append(frame_number - 1)
-
+            frame_idx_to_text_prompt, max_frame_num_to_track, track_dir = self._get_tracking_config(
+                chunk.node, frame_number
+            )
             logger.info(f"frame_idx_to_text_prompt: {frame_idx_to_text_prompt}; direction = {track_dir}")
 
-            for idx, _ in enumerate(chunk_image_paths):
-                img, h_ori, w_ori, PAR, orientation = image.loadImage(str(chunk_image_paths[idx][0]), True)
-                pil_images.append(Image.fromarray((255.0 * img).astype("uint8")))
-                source_info = {"h_ori": h_ori, "w_ori": w_ori, "PAR": PAR, "orientation": orientation}
-                mask_images.append(np.zeros_like(img))
-
-                if first_frame_id is None or chunk_image_paths[idx][2] is None:
-                    frame_id = idx
-                else:
-                    frame_id = chunk_image_paths[idx][2] - first_frame_id
+            pil_images, mask_images, source_info = self._load_source_images(chunk_image_paths)
 
             response = video_predictor.handle_request(
-                request=dict(
-                    type="start_session",
-                    resource_path=pil_images,
-                    )
+                request={"type": "start_session", "resource_path": pil_images}
             )
             session_id = response["session_id"]
 
@@ -299,7 +327,7 @@ from a text prompt.
                 for frame_id in range(frame_number):
                     metadata_boxes[frame_id][text_prompt] = {"forward": {}, "backward": {}, "merged": {}}
 
-                video_predictor.handle_request(request=dict(type="reset_session", session_id=session_id))
+                video_predictor.handle_request(request={"type": "reset_session", "session_id": session_id})
 
                 outputs_per_frame = {}
 
@@ -315,12 +343,12 @@ from a text prompt.
                     logger.info(f"text prompt at relative frame {frame_idx} (absolute frame {int(first_frame_id) + frame_idx})")
 
                     video_predictor.handle_request(
-                        request=dict(
-                            type="add_prompt",
-                            session_id=session_id,
-                            frame_index=frame_idx,
-                            text=text_prompt,
-                        )
+                        request={
+                            "type": "add_prompt",
+                            "session_id": session_id,
+                            "frame_index": frame_idx,
+                            "text": text_prompt
+                        }
                     )
                     outputs_per_frame[frame_idx] = sam3Utils.propagateInVideo(video_predictor, session_id, frame_idx, max_frame_num_to_track, track_dir)
 
@@ -348,7 +376,7 @@ from a text prompt.
                         track_fwd = sam3Utils.prepareMasksForVisualization(outputs_per_frame[frame_idx])
                         first_frame = frame_idx
                         last_frame = frame_idx if n == len(frame_idx_to_text_prompt) - 1 else frame_idx_to_text_prompt[n + 1]
-                        fwd = {k: v for k, v in track_fwd.items() if k >= first_frame and k <= last_frame}
+                        fwd = self._slice_track(track_fwd, first_frame, last_frame)
 
                         fwd_only, prev_overlap_detections_fwd, next_global_id_fwd = self._update_global_ids(
                             fwd, prev_overlap_detections_fwd, next_global_id_fwd, color_palette
@@ -360,7 +388,7 @@ from a text prompt.
 
                             first_frame = frame_idx_to_text_prompt[n - 1]
                             last_frame = frame_idx
-                            bwd = {k: v for k, v in track_bwd.items() if k >= first_frame and k <= last_frame}
+                            bwd = self._slice_track(track_bwd, first_frame, last_frame)
 
                             bwd_only, prev_overlap_detections_bwd, next_global_id_bwd = self._update_global_ids(
                                 bwd, prev_overlap_detections_bwd, next_global_id_bwd, color_palette
@@ -372,8 +400,8 @@ from a text prompt.
                             track_bwd_for_merge = sam3Utils.prepareMasksForVisualization(outputs_per_frame[frame_idx])
                             first_frame = frame_idx_to_text_prompt[n - 1]
                             last_frame = frame_idx
-                            fwd_for_merge = {k: v for k, v in track_fwd_for_merge.items() if k >= first_frame and k <= last_frame}
-                            bwd_for_merge = {k: v for k, v in track_bwd_for_merge.items() if k >= first_frame and k <= last_frame}
+                            fwd_for_merge = self._slice_track(track_fwd_for_merge, first_frame, last_frame)
+                            bwd_for_merge = self._slice_track(track_bwd_for_merge, first_frame, last_frame)
 
                             fwd_bwd, prev_overlap_detections_merged, next_global_id_merged = sam3Utils.merge_tracks(
                                 fwd_results=fwd_for_merge,
@@ -395,11 +423,11 @@ from a text prompt.
                     logger.debug(f"Extract boxes for frame Fwd from : {frame_idx} to {last_frame_idx_fwd - 1}")
 
                     for frame_id in range(frame_idx, last_frame_idx_fwd):
-                        color_mask_image_fwd = np.zeros_like(img)
+                        color_mask_image_fwd = np.zeros(source_info["shape"], dtype=source_info["dtype"])
 
                         if chunk.node.outputCryptomatte.value:
-                            crypto_id_fwd = np.zeros((img.shape[0], img.shape[1]), dtype=np.float32)
-                            crypto_cov_fwd = np.zeros((img.shape[0], img.shape[1]), dtype=np.float32)
+                            crypto_id_fwd = np.zeros((source_info["h_ori"], source_info["w_ori"]), dtype=np.float32)
+                            crypto_cov_fwd = np.zeros((source_info["h_ori"], source_info["w_ori"]), dtype=np.float32)
                             manifest_fwd = {}
 
                         boxes[text_prompt]["forward"][first_frame_id + frame_id] = {}
@@ -431,16 +459,16 @@ from a text prompt.
 
                         if chunk.node.outputCryptomatte.value:
                             cryptomatte_path = self._build_output_path(chunk, chunk_image_paths, frame_id, "cryptomatte_" + text_prompt + "_fwd_", ".exr")
-                            image.writeCryptomatte(cryptomatte_path, crypto_name, img.shape[1], img.shape[0], manifest_fwd, crypto_id_fwd, crypto_cov_fwd)
+                            image.writeCryptomatte(cryptomatte_path, crypto_name, source_info["w_ori"], source_info["h_ori"], manifest_fwd, crypto_id_fwd, crypto_cov_fwd)
 
                     if chunk.node.combineFwdAndBwdSeg.value:
                         # write Bwd from frame_idx_to_text_prompt[n - 1] to frame_idx
                         first_frame_idx_bwd = frame_idx_to_text_prompt[n - 1] + 1 if n > 0 else frame_idx
                         for frame_id in range(first_frame_idx_bwd, frame_idx + 1):
-                            color_mask_image_bwd = np.zeros_like(img)
+                            color_mask_image_bwd = np.zeros(source_info["shape"], dtype=source_info["dtype"])
                             if chunk.node.outputCryptomatte.value:
-                                crypto_id_bwd = np.zeros((img.shape[0], img.shape[1]), dtype=np.float32)
-                                crypto_cov_bwd = np.zeros((img.shape[0], img.shape[1]), dtype=np.float32)
+                                crypto_id_bwd = np.zeros((source_info["h_ori"], source_info["w_ori"]), dtype=np.float32)
+                                crypto_cov_bwd = np.zeros((source_info["h_ori"], source_info["w_ori"]), dtype=np.float32)
                                 manifest_bwd = {}
                             boxes[text_prompt]["backward"][first_frame_id + frame_id] = {}
                             for key, mask_box_prob in bwd_only[frame_id].items():
@@ -468,11 +496,11 @@ from a text prompt.
 
                             if chunk.node.outputCryptomatte.value:
                                 cryptomatte_path = self._build_output_path(chunk, chunk_image_paths, frame_id, "cryptomatte_" + text_prompt + "_bwd_", ".exr")
-                                image.writeCryptomatte(cryptomatte_path, crypto_name, img.shape[1], img.shape[0], manifest_bwd, crypto_id_bwd, crypto_cov_bwd)
+                                image.writeCryptomatte(cryptomatte_path, crypto_name, source_info["w_ori"], source_info["h_ori"], manifest_bwd, crypto_id_bwd, crypto_cov_bwd)
 
                         if n > 0:
                             for frame_id in range(first_frame_idx_bwd - 1, frame_idx + 1):
-                                color_mask_image_merged = np.zeros_like(img)
+                                color_mask_image_merged = np.zeros(source_info["shape"], dtype=source_info["dtype"])
                                 boxes[text_prompt]["merged"][first_frame_id + frame_id] = {}
                                 for key, mask_box_prob in fwd_bwd[frame_id].items():
                                     mask = mask_box_prob["mask"]
@@ -522,7 +550,7 @@ from a text prompt.
             with open(json_filename, "w", encoding="utf_8") as file:
                 json.dump(boxes, file, indent=4, ensure_ascii=False)
 
-            video_predictor.handle_request(request=dict(type="close_session", session_id=session_id))
+            video_predictor.handle_request(request={"type": "close_session", "session_id": session_id})
 
         finally:
             torch.cuda.empty_cache()

--- a/meshroom/sam3/VideoSegmentationSam3Text.py
+++ b/meshroom/sam3/VideoSegmentationSam3Text.py
@@ -301,12 +301,21 @@ from a text prompt.
                     if n == 0:
                         fwd_only = sam3Utils.prepareMasksForVisualization(outputs_per_frame[fIdx])
                         bwd_only = sam3Utils.prepareMasksForVisualization(outputs_per_frame[fIdx])
-                        prev_overlap_detections_bwd = bwd_only[0]
-                        if bwd_only[0].keys():
-                            next_global_id_bwd = max(bwd_only[0].keys()) + 1
-                        logger.info(f"next_global_id_bwd = {next_global_id_bwd}")
-                    else:
 
+                        # Initialize prev_overlap_detections_bwd with global IDs
+                        # by running a trivial assign_global_ids on just frame 0
+                        bwd_frame0_only = {fIdx: bwd_only[fIdx]}
+                        _, prev_overlap_detections_bwd, next_global_id_bwd = sam3Utils.assign_global_ids(
+                            bwd_frame0_only,
+                            {},
+                            next_global_id_bwd,
+                            similatity_threshold=0.4,
+                            use_mask=True,
+                        )
+                        colorPalette.generate_palette(next_global_id_bwd + 1)
+                        logger.info(f"next_global_id_bwd = {next_global_id_bwd}")
+
+                    else:
                         track_fwd = sam3Utils.prepareMasksForVisualization(outputs_per_frame[fIdx])
                         firstFrame = fIdx
                         lastFrame = fIdx if n == len(frameIdxToTextPrompt) - 1 else frameIdxToTextPrompt[n + 1]

--- a/meshroom/sam3/VideoSegmentationSam3Text.py
+++ b/meshroom/sam3/VideoSegmentationSam3Text.py
@@ -1,12 +1,14 @@
 __version__ = "1.2"
 
+import copy
 import logging
 import os
 from pathlib import Path
+import re
 
+from pyalicevision import parallelization as avpar
 from meshroom.core import desc
 from meshroom.core.utils import VERBOSE_LEVEL
-from pyalicevision import parallelization as avpar
 
 logger = logging.getLogger("VideoSegmentationSam3Text")
 
@@ -162,6 +164,7 @@ from a text prompt.
     ]
 
     def _build_output_path(self, node, frame_id, prefix, extension):
+        """ Constructs an absolute output filepath based on the preferred naming methods. """
         if node.keepFilename.value:
             path = str(Path(self.image_paths[frame_id][0]).stem)
         else:
@@ -169,7 +172,7 @@ from a text prompt.
         return os.path.join(node.output.value, prefix + path + extension)
 
     def _update_global_ids(self, results, prev_overlap, next_id, color_palette):
-        """ Helper to assign global IDs and expand the color palette. """
+        """ Assigns global tracking IDs and expands the color palette. """
         from segmentationRDS import sam3Utils
 
         updated_res, next_prev_overlap, updated_id = sam3Utils.assign_global_ids(
@@ -187,11 +190,12 @@ from a text prompt.
         return {k: v for k, v in track_data.items() if start <= k <= end}
 
     def _get_tracking_config(self, node, frame_number):
-        """ Helper to determine frame steps and direction for tracking. """
+        """ Determines directional limits, frame step intervals and slicing logic. """
         frame_idx_to_text_prompt = [0]
         max_frame_num_to_track = None
         track_dir = "forward"
 
+        # Construct frame sequence intervals if time slicing is active
         if node.timeSlicing.value:
             max_frame_num_to_track = node.sliceSize.value
             curr_frame_to_text_prompt = 0
@@ -207,7 +211,7 @@ from a text prompt.
         return frame_idx_to_text_prompt, max_frame_num_to_track, track_dir
 
     def _load_source_images(self):
-        """ Helper to load input images, prepare PIL frames, and extract dimensions. """
+        """ Loads input images, generates baseline empty masks, and indexes camera dimensions. """
         from PIL import Image
         from segmentationRDS import image
         import numpy as np
@@ -217,7 +221,7 @@ from a text prompt.
         source_info = None
 
         for idx, path_data in enumerate(self.image_paths):
-            img, h_ori, w_ori, PAR, orientation = image.loadImage(str(path_data[0]), True)
+            img, h_ori, w_ori, par, orientation = image.loadImage(str(path_data[0]), True)
             pil_images.append(Image.fromarray((255.0 * img).astype("uint8")))
 
             # Store source dimensions from the first image (assumed uniform)
@@ -225,7 +229,7 @@ from a text prompt.
                 source_info = {
                     "h_ori": h_ori,
                     "w_ori": w_ori,
-                    "PAR": PAR,
+                    "PAR": par,
                     "orientation": orientation,
                     "shape": img.shape,
                     "dtype": img.dtype
@@ -238,8 +242,8 @@ from a text prompt.
         self,
         node,
         frame_range,
-        direction_name,          # "forward", "backward", "merged"
-        direction_results,       # fwd_only, bwd_only, fwd_bwd
+        direction_name,
+        direction_results,
         text_prompt,
         color_palette,
         source_info,
@@ -305,7 +309,7 @@ from a text prompt.
                 color = color_palette.at(int(key)) if color_palette.at(int(key)) is not None else [255, 255, 255]
                 color_mask_image[mask] = [x / 255.0 for x in color]
 
-                # Process Cryptomatte hashes (matches old f"{crypto_name}_{dir_prefix}_{int(key)}")
+                # Generate IDs and hash structures for cryptomatte EXRs
                 if output_crypto:
                     obj_name = f"{crypto_name}_{dir_prefix}_{int(key)}"
                     f32_hash, hex_val, _ = image.hash_name(obj_name)
@@ -317,7 +321,7 @@ from a text prompt.
                 bbox = sam3Utils.xywhNorm2xyxy(mask_box_prob["box_xywh"], source_info["w_ori"], source_info["h_ori"])
                 boxes[text_prompt][direction_name][first_frame_id + frame_id][key] = bbox
 
-                # Metadata writes (matches old: "fwd_" + text_prompt + "_" + str(key))
+                # Write the bounding boxes into the frame's metadata
                 x1, y1, x2, y2 = bbox
                 bbox_str = f"{x1};{y1};{x2};{y2}"
                 metadata_boxes[frame_id][text_prompt][direction_name][f"{dir_prefix}_{text_prompt}_{key}"] = bbox_str
@@ -326,8 +330,8 @@ from a text prompt.
             if node.outputColorMasks.value:
                 prefix = f"colorMask_{text_prompt}_{dir_prefix}_"
                 output_file_color_mask = self._build_output_path(node, frame_id, prefix, color_mask_ext)
-                optWrite = avimg.ImageWriteOptions()
-                optWrite.toColorSpace(avimg.EImageColorSpace_NO_CONVERSION)
+                opt_write = avimg.ImageWriteOptions()
+                opt_write.toColorSpace(avimg.EImageColorSpace_NO_CONVERSION)
                 image.writeImage(
                     output_file_color_mask,
                     color_mask_image,
@@ -336,7 +340,7 @@ from a text prompt.
                     source_info["orientation"],
                     source_info["PAR"],
                     metadata_deep_model,
-                    optWrite
+                    opt_write
                 )
 
             # Save Cryptomatte Multichannel EXR
@@ -363,8 +367,7 @@ from a text prompt.
         color_palette,
         combine_fwd_bwd
     ):
-        """ Helper to process and slice forward/backward tracks and update global IDs. """
-        import copy
+        """ Processes temporal tracking slices, resolves global IDs, and manages historical memory. """
         from segmentationRDS import sam3Utils
 
         # Call prepareMasksForVisualization once per raw outputs dictionary to prevent repeating mutating calls
@@ -397,7 +400,8 @@ from a text prompt.
             if combine_fwd_bwd:
                 merged_frame0_only = {frame_idx: fwd_only[frame_idx]}
                 fwd_bwd, track_states["merged"]["prev_overlap"], track_states["merged"]["next_id"] = self._update_global_ids(
-                    merged_frame0_only, track_states["merged"]["prev_overlap"], track_states["merged"]["next_id"], color_palette
+                    merged_frame0_only, track_states["merged"]["prev_overlap"],
+                    track_states["merged"]["next_id"], color_palette
                 )
                 logger.info(f"next_global_id_merged = {track_states['merged']['next_id']}")
 
@@ -408,7 +412,10 @@ from a text prompt.
         first_frame = frame_idx
 
         # Keep the remaining forward frames on the last segment instead of truncating to frame_idx
-        last_frame = max(track_fwd.keys()) if n == len(frame_idx_to_text_prompt) - 1 else frame_idx_to_text_prompt[n + 1]
+        if n == len(frame_idx_to_text_prompt) - 1:
+            last_frame = max(track_fwd.keys())
+        else:
+            last_frame = frame_idx_to_text_prompt[n + 1]
         fwd = self._slice_track(track_fwd, first_frame, last_frame)
 
         fwd_only, track_states["fwd"]["prev_overlap"], track_states["fwd"]["next_id"] = self._update_global_ids(
@@ -455,8 +462,7 @@ from a text prompt.
         return fwd_only, bwd_only, fwd_bwd
 
     def resolve_paths(self, node):
-        import re
-
+        """ Constructs system template paths mapping to the node output parameters. """
         if node.prompt.value == "":
             raise ValueError("Text prompt is empty.")
 
@@ -466,8 +472,10 @@ from a text prompt.
             raise FileNotFoundError(f"No image files found in {input_path}.")
         self.image_paths = image_paths
 
+        # Parse and sanitize multi-line prompt lists
         self.text_prompts = re.split(r'[\n]+', node.prompt.value)
         self.text_prompts = [str(text_prompt) for text_prompt in self.text_prompts if text_prompt]
+
         src_filename = "<FILESTEM>" if node.keepFilename.value else "<VIEW_ID>"
 
         color_mask_prefix = node.output.value + "/colorMask_" + self.text_prompts[0]
@@ -520,6 +528,7 @@ from a text prompt.
             pil_images, mask_images, source_info = self._load_source_images()
             source_info["first_frame_id"] = first_frame_id
 
+            # Start tracking session
             response = video_predictor.handle_request(
                 request={"type": "start_session", "resource_path": pil_images}
             )
@@ -534,8 +543,9 @@ from a text prompt.
                 "metadata_boxes": metadata_boxes
             }
 
+            # Run temporal tracking queries per text prompt configuration
             for text_prompt in self.text_prompts:
-                logger.info(f"Text prompt: {text_prompt}")
+                logger.info(f"Processing prompt: {text_prompt}")
 
                 boxes[text_prompt] = {"forward": {}, "backward": {}, "merged": {}}
                 metadata_deep_model["Meshroom:mrSegmentation:Prompt"] = text_prompt
@@ -554,7 +564,8 @@ from a text prompt.
                 }
 
                 for n, frame_idx in enumerate(frame_idx_to_text_prompt):
-                    logger.info(f"text prompt at relative frame {frame_idx} (absolute frame {int(first_frame_id) + frame_idx})")
+                    abs_frame = int(first_frame_id) + frame_idx
+                    logger.info(f"Text prompt at relative frame {frame_idx} (absolute frame {abs_frame})")
 
                     video_predictor.handle_request(
                         request={
@@ -564,7 +575,9 @@ from a text prompt.
                             "text": text_prompt
                         }
                     )
-                    outputs_per_frame[frame_idx] = sam3Utils.propagateInVideo(video_predictor, session_id, frame_idx, max_frame_num_to_track, track_dir)
+                    outputs_per_frame[frame_idx] = sam3Utils.propagateInVideo(video_predictor, session_id,
+                                                                              frame_idx, max_frame_num_to_track,
+                                                                              track_dir)
 
                     fwd_only, bwd_only, fwd_bwd = self._update_tracking_at_step(
                         n=n,
@@ -577,9 +590,10 @@ from a text prompt.
                     )
 
                     # write Fwd from frame_idx to frame_idx_to_text_prompt[n + 1]
-                    last_frame_idx_fwd = frame_idx_to_text_prompt[n + 1] if n < len(frame_idx_to_text_prompt) - 1 else frame_number
-
-                    logger.debug(f"Extract boxes for frame Fwd from : {frame_idx} to {last_frame_idx_fwd - 1}")
+                    last_frame_idx_fwd = frame_number
+                    if n < len(frame_idx_to_text_prompt) - 1:
+                        last_frame_idx_fwd = frame_idx_to_text_prompt[n + 1]
+                    logger.debug(f"Exporting forward boxes from frame index {frame_idx} to {last_frame_idx_fwd - 1}")
 
                     self._export_direction_masks(
                         node=chunk.node,
@@ -625,6 +639,7 @@ from a text prompt.
             prompts = [text_prompt.strip() for text_prompt in self.text_prompts if text_prompt.strip()]
             metadata_deep_model["Meshroom:mrSegmentation:Prompt"] = ";".join(prompts)
 
+            logger.info("Writing definitive binary masks to disk...")
             for frame_id in range(frame_number):
                 if chunk.node.maskInvert.value:
                     mask = (mask_images[frame_id][:, :, 0:1] == 0).astype('float32')
@@ -633,12 +648,12 @@ from a text prompt.
                 logger.info(f"frame_id: {frame_id} - {self.image_paths[frame_id][0]}")
 
                 output_file_mask = self._build_output_path(chunk.node, frame_id, "", "." + chunk.node.extensionOut.value)
-                optWrite = avimg.ImageWriteOptions()
-                optWrite.toColorSpace(avimg.EImageColorSpace_NO_CONVERSION)
+                opt_write = avimg.ImageWriteOptions()
+                opt_write.toColorSpace(avimg.EImageColorSpace_NO_CONVERSION)
 
                 if Path(output_file_mask).suffix.lower() == ".exr":
-                    optWrite.exrCompressionMethod(avimg.EImageExrCompression_stringToEnum("DWAA"))
-                    optWrite.exrCompressionLevel(300)
+                    opt_write.exrCompressionMethod(avimg.EImageExrCompression_stringToEnum("DWAA"))
+                    opt_write.exrCompressionLevel(300)
 
                 frame_metadata_deep_model = dict(metadata_deep_model)
                 for prompt in self.text_prompts:
@@ -646,9 +661,12 @@ from a text prompt.
                         for k, box in metadata_boxes[frame_id][prompt][direction].items():
                             frame_metadata_deep_model["Meshroom:mrSegmentation:" + k] = box
 
-                image.writeImage(output_file_mask, mask, source_info["h_ori"], source_info["w_ori"], source_info["orientation"], source_info["PAR"], frame_metadata_deep_model, optWrite)
+                image.writeImage(output_file_mask, mask, source_info["h_ori"],
+                                 source_info["w_ori"], source_info["orientation"],
+                                 source_info["PAR"], frame_metadata_deep_model, opt_write)
 
             json_filename = chunk.node.output.value + "/bboxes.json"
+            logger.info(f"Writing bounding boxes metadata to {json_filename}")
             with open(json_filename, "w", encoding="utf_8") as file:
                 json.dump(boxes, file, indent=4, ensure_ascii=False)
 

--- a/meshroom/sam3/VideoSegmentationSam3Text.py
+++ b/meshroom/sam3/VideoSegmentationSam3Text.py
@@ -271,6 +271,11 @@ from a text prompt.
         boxes = state["boxes"]
         metadata_boxes = state["metadata_boxes"]
 
+        is_definitive = (
+            (node.combineFwdAndBwdSeg.value and direction_name == "merged") or
+            (not node.combineFwdAndBwdSeg.value and direction_name == "forward")
+        )
+
         write_cryptomatte = (direction_name in ["forward", "backward"])
         crypto_name = "object" if text_prompt == "" else text_prompt
 
@@ -292,8 +297,9 @@ from a text prompt.
             for key, mask_box_prob in frame_detections.items():
                 mask = mask_box_prob["mask"]
 
-                # Draw composite binary mask (for final step)
-                mask_images[frame_id][mask] = [(int(key) + 1) * 255, 255, 255]
+                # Write binary mask corresponding to the definitive pass (forward if no merging, merged otherwise)
+                if is_definitive:
+                    mask_images[frame_id][mask] = [(int(key) + 1) * 255, 255, 255]
 
                 # Draw visual color mask
                 color = color_palette.at(int(key)) if color_palette.at(int(key)) is not None else [255, 255, 255]

--- a/meshroom/sam3/VideoSegmentationSam3Text.py
+++ b/meshroom/sam3/VideoSegmentationSam3Text.py
@@ -1,5 +1,6 @@
 __version__ = "1.2"
 
+import logging
 import os
 from pathlib import Path
 
@@ -7,18 +8,20 @@ from meshroom.core import desc
 from meshroom.core.utils import VERBOSE_LEVEL
 from pyalicevision import parallelization as avpar
 
-import logging
 logger = logging.getLogger("VideoSegmentationSam3Text")
 
 class VideoSegmentationSam3Text(desc.Node):
-    size = avpar.DynamicViewsSize("input")
-    gpu = lambda node: desc.Level.EXTREME if node.useOnlyHighPowerGpu.value else desc.Level.INTENSIVE
-
-    category = "Segmentation"
-    documentation = """
+    """
 Based on the Segment Anything video predictor model 3, the node generates a binary mask, a colored mask and an exr cryptomatte
 from a text prompt.
 """
+    size = avpar.DynamicViewsSize("input")
+    gpu = lambda node: desc.Level.EXTREME if node.useOnlyHighPowerGpu.value else desc.Level.INTENSIVE
+
+    text_prompts = []
+    image_paths = []
+
+    category = "Segmentation"
 
     inputs = [
         desc.File(
@@ -165,7 +168,7 @@ from a text prompt.
             path = str(paths[frame_id][1])
         return os.path.join(chunk.node.output.value, prefix + path + extension)
 
-    def resolvePaths(self, node):
+    def resolve_paths(self, node):
         import re
 
         if node.prompt.value == "":
@@ -180,8 +183,10 @@ from a text prompt.
         self.text_prompts = re.split(r'[\n]+', node.prompt.value)
         self.text_prompts = [str(text_prompt) for text_prompt in self.text_prompts if text_prompt]
         src_filename = "<FILESTEM>" if node.keepFilename.value else "<VIEW_ID>"
+
         color_mask_prefix = node.output.value + "/colorMask_" + self.text_prompts[0]
         cryptomatte_prefix = node.output.value + "/cryptomatte_" + self.text_prompts[0]
+
         node.colorMasksFwd.value = color_mask_prefix + "_fwd_" + src_filename + ".exr"
         node.colorMasksBwd.value = color_mask_prefix + "_bwd_" + src_filename + ".png"
         node.colorMasksMerged.value = color_mask_prefix + "_merged_" + src_filename + ".exr"
@@ -199,8 +204,7 @@ from a text prompt.
         import json
 
         try:
-
-            self.resolvePaths(chunk.node)
+            self.resolve_paths(chunk.node)
 
             logger.setLevel(chunk.node.verboseLevel.value.upper())
 
@@ -218,7 +222,8 @@ from a text prompt.
                 os.mkdir(chunk.node.output.value)
 
             gpus_to_use = [torch.cuda.current_device()]
-            video_predictor = build_sam3_video_predictor(checkpoint_path=chunk.node.segmentationModelPath.evalValue, gpus_to_use=gpus_to_use)
+            video_predictor = build_sam3_video_predictor(checkpoint_path=chunk.node.segmentationModelPath.evalValue,
+                                                         gpus_to_use=gpus_to_use)
 
             metadata_deep_model = {}
             metadata_deep_model["Meshroom:mrSegmentation:DeepModelName"] = "SegmentAnything"
@@ -227,36 +232,36 @@ from a text prompt.
             pil_images = []
             mask_images = []
 
-            colorPalette = image.paletteGenerator()
-            firstFrameId = chunk_image_paths[0][2]
-            frameNumber = len(chunk_image_paths)
+            color_palette = image.paletteGenerator()
+            first_frame_id = chunk_image_paths[0][2]
+            frame_number = len(chunk_image_paths)
 
-            frameIdxToTextPrompt = [0]
+            frame_idx_to_text_prompt = [0]
             max_frame_num_to_track = None
             track_dir = "forward"
             if chunk.node.timeSlicing.value:
                 max_frame_num_to_track = chunk.node.sliceSize.value
                 currFrameToTextPrompt = 0
-                while currFrameToTextPrompt + chunk.node.sliceSize.value < frameNumber:
+                while currFrameToTextPrompt + chunk.node.sliceSize.value < frame_number:
                     currFrameToTextPrompt += chunk.node.sliceSize.value
-                    frameIdxToTextPrompt.append(currFrameToTextPrompt)
+                    frame_idx_to_text_prompt.append(currFrameToTextPrompt)
             if chunk.node.combineFwdAndBwdSeg.value:
                 track_dir = "both"
-                if frameIdxToTextPrompt[-1] < frameNumber - 1:
-                    frameIdxToTextPrompt.append(frameNumber - 1)
+                if frame_idx_to_text_prompt[-1] < frame_number - 1:
+                    frame_idx_to_text_prompt.append(frame_number - 1)
 
-            logger.info(f"frameIdxToTextPrompt: {frameIdxToTextPrompt}; direction = {track_dir}")
+            logger.info(f"frame_idx_to_text_prompt: {frame_idx_to_text_prompt}; direction = {track_dir}")
 
-            for idx, path in enumerate(chunk_image_paths):
+            for idx, _ in enumerate(chunk_image_paths):
                 img, h_ori, w_ori, PAR, orientation = image.loadImage(str(chunk_image_paths[idx][0]), True)
                 pil_images.append(Image.fromarray((255.0 * img).astype("uint8")))
-                sourceInfo = {"h_ori": h_ori, "w_ori": w_ori, "PAR": PAR, "orientation": orientation}
+                source_info = {"h_ori": h_ori, "w_ori": w_ori, "PAR": PAR, "orientation": orientation}
                 mask_images.append(np.zeros_like(img))
 
-                if firstFrameId is None or chunk_image_paths[idx][2] is None:
-                    frameId = idx
+                if first_frame_id is None or chunk_image_paths[idx][2] is None:
+                    frame_id = idx
                 else:
-                    frameId = chunk_image_paths[idx][2] - firstFrameId
+                    frame_id = chunk_image_paths[idx][2] - first_frame_id
 
             response = video_predictor.handle_request(
                 request=dict(
@@ -268,17 +273,17 @@ from a text prompt.
 
             boxes = {}
             metadata_boxes = {}
-            for frameId in range(frameNumber):
-                metadata_boxes[frameId] = {}
+            for frame_id in range(frame_number):
+                metadata_boxes[frame_id] = {}
 
-            for textPrompt in self.text_prompts:
+            for text_prompt in self.text_prompts:
 
-                logger.info(f"textPrompt: {textPrompt}")
-                boxes[textPrompt] = {"forward": {}, "backward": {}, "merged": {}}
-                cryptoName = "object" if textPrompt == "" else textPrompt
-                metadata_deep_model["Meshroom:mrSegmentation:Prompt"] = textPrompt
-                for frameId in range(frameNumber):
-                    metadata_boxes[frameId][textPrompt] = {"forward": {}, "backward": {}, "merged": {}}
+                logger.info(f"Text prompt: {text_prompt}")
+                boxes[text_prompt] = {"forward": {}, "backward": {}, "merged": {}}
+                crypto_name = "object" if text_prompt == "" else text_prompt
+                metadata_deep_model["Meshroom:mrSegmentation:Prompt"] = text_prompt
+                for frame_id in range(frame_number):
+                    metadata_boxes[frame_id][text_prompt] = {"forward": {}, "backward": {}, "merged": {}}
 
                 video_predictor.handle_request(request=dict(type="reset_session", session_id=session_id))
 
@@ -291,27 +296,27 @@ from a text prompt.
                 prev_overlap_detections_merged = {}
                 next_global_id_merged: int = 0
 
-                for n, fIdx in enumerate(frameIdxToTextPrompt):
+                for n, frame_idx in enumerate(frame_idx_to_text_prompt):
 
-                    logger.info(f"text prompt at relative frame {fIdx} (absolute frame {int(firstFrameId) + fIdx})")
+                    logger.info(f"text prompt at relative frame {frame_idx} (absolute frame {int(first_frame_id) + frame_idx})")
 
                     video_predictor.handle_request(
                         request=dict(
                             type="add_prompt",
                             session_id=session_id,
-                            frame_index=fIdx,
-                            text=textPrompt,
+                            frame_index=frame_idx,
+                            text=text_prompt,
                         )
                     )
-                    outputs_per_frame[fIdx] = sam3Utils.propagateInVideo(video_predictor, session_id, fIdx, max_frame_num_to_track, track_dir)
+                    outputs_per_frame[frame_idx] = sam3Utils.propagateInVideo(video_predictor, session_id, frame_idx, max_frame_num_to_track, track_dir)
 
                     if n == 0:
-                        fwd_only = sam3Utils.prepareMasksForVisualization(outputs_per_frame[fIdx])
-                        bwd_only = sam3Utils.prepareMasksForVisualization(outputs_per_frame[fIdx])
+                        fwd_only = sam3Utils.prepareMasksForVisualization(outputs_per_frame[frame_idx])
+                        bwd_only = sam3Utils.prepareMasksForVisualization(outputs_per_frame[frame_idx])
 
                         # Initialize prev_overlap_detections_bwd with global IDs
                         # by running a trivial assign_global_ids on just frame 0
-                        bwd_frame0_only = {fIdx: bwd_only[fIdx]}
+                        bwd_frame0_only = {frame_idx: bwd_only[frame_idx]}
                         _, prev_overlap_detections_bwd, next_global_id_bwd = sam3Utils.assign_global_ids(
                             bwd_frame0_only,
                             {},
@@ -324,7 +329,7 @@ from a text prompt.
 
                         # Initialize merged tracking for n == 0 as well
                         if chunk.node.combineFwdAndBwdSeg.value:
-                            merged_frame0_only = {fIdx: fwd_only[fIdx]}
+                            merged_frame0_only = {frame_idx: fwd_only[frame_idx]}
                             fwd_bwd, prev_overlap_detections_merged, next_global_id_merged = sam3Utils.assign_global_ids(
                                 merged_frame0_only,
                                 {},
@@ -332,14 +337,14 @@ from a text prompt.
                                 similarity_threshold=0.4,
                                 use_mask=True,
                             )
-                            colorPalette.generate_palette(next_global_id_merged + 1)
+                            color_palette.generate_palette(next_global_id_merged + 1)
                             logger.info(f"next_global_id_merged = {next_global_id_merged}")
 
                     else:
-                        track_fwd = sam3Utils.prepareMasksForVisualization(outputs_per_frame[fIdx])
-                        firstFrame = fIdx
-                        lastFrame = fIdx if n == len(frameIdxToTextPrompt) - 1 else frameIdxToTextPrompt[n + 1]
-                        fwd = {k: v for k,v in track_fwd.items() if k >= firstFrame and k <= lastFrame}
+                        track_fwd = sam3Utils.prepareMasksForVisualization(outputs_per_frame[frame_idx])
+                        first_frame = frame_idx
+                        last_frame = frame_idx if n == len(frame_idx_to_text_prompt) - 1 else frame_idx_to_text_prompt[n + 1]
+                        fwd = {k: v for k, v in track_fwd.items() if k >= first_frame and k <= last_frame}
 
                         fwd_only, prev_overlap_detections_fwd, next_global_id_fwd = sam3Utils.assign_global_ids(
                             fwd,
@@ -348,16 +353,15 @@ from a text prompt.
                             similarity_threshold=0.4,
                             use_mask=True,
                         )
-                        colorPalette.generate_palette(next_global_id_fwd + 1)
+                        color_palette.generate_palette(next_global_id_fwd + 1)
                         logger.info(f"next_global_id_fwd = {next_global_id_fwd}")
 
                         if chunk.node.combineFwdAndBwdSeg.value:
+                            track_bwd = sam3Utils.prepareMasksForVisualization(outputs_per_frame[frame_idx])
 
-                            track_bwd = sam3Utils.prepareMasksForVisualization(outputs_per_frame[fIdx])
-
-                            firstFrame = frameIdxToTextPrompt[n - 1]
-                            lastFrame = fIdx
-                            bwd = {k: v for k,v in track_bwd.items() if k >= firstFrame and k <= lastFrame}
+                            first_frame = frame_idx_to_text_prompt[n - 1]
+                            last_frame = frame_idx
+                            bwd = {k: v for k, v in track_bwd.items() if k >= first_frame and k <= last_frame}
 
                             bwd_only, prev_overlap_detections_bwd, next_global_id_bwd = sam3Utils.assign_global_ids(
                                 bwd,
@@ -366,16 +370,16 @@ from a text prompt.
                                 similarity_threshold=0.4,
                                 use_mask=True,
                             )
-                            colorPalette.generate_palette(next_global_id_bwd + 1)
+                            color_palette.generate_palette(next_global_id_bwd + 1)
                             logger.info(f"next_global_id_bwd = {next_global_id_bwd}")
 
                             # Create FRESH copies for merge_tracks since the previous calls cleared the dicts
-                            track_fwd_for_merge = sam3Utils.prepareMasksForVisualization(outputs_per_frame[frameIdxToTextPrompt[n - 1]])
-                            track_bwd_for_merge = sam3Utils.prepareMasksForVisualization(outputs_per_frame[fIdx])
-                            firstFrame = frameIdxToTextPrompt[n - 1]
-                            lastFrame = fIdx
-                            fwd_for_merge = {k: v for k,v in track_fwd_for_merge.items() if k >= firstFrame and k <= lastFrame}
-                            bwd_for_merge = {k: v for k,v in track_bwd_for_merge.items() if k >= firstFrame and k <= lastFrame}
+                            track_fwd_for_merge = sam3Utils.prepareMasksForVisualization(outputs_per_frame[frame_idx_to_text_prompt[n - 1]])
+                            track_bwd_for_merge = sam3Utils.prepareMasksForVisualization(outputs_per_frame[frame_idx])
+                            first_frame = frame_idx_to_text_prompt[n - 1]
+                            last_frame = frame_idx
+                            fwd_for_merge = {k: v for k, v in track_fwd_for_merge.items() if k >= first_frame and k <= last_frame}
+                            bwd_for_merge = {k: v for k, v in track_bwd_for_merge.items() if k >= first_frame and k <= last_frame}
 
                             fwd_bwd, prev_overlap_detections_merged, next_global_id_merged = sam3Utils.merge_tracks(
                                 fwd_results=fwd_for_merge,
@@ -386,141 +390,143 @@ from a text prompt.
                                 similarity_threshold_track=0.4,
                                 use_mask=True,
                             )
-                            colorPalette.generate_palette(next_global_id_merged + 1)
+                            color_palette.generate_palette(next_global_id_merged + 1)
                             logger.info(f"next_global_id_merged = {next_global_id_merged}")
 
-                        del outputs_per_frame[frameIdxToTextPrompt[n - 1]]
+                        del outputs_per_frame[frame_idx_to_text_prompt[n - 1]]
 
-                    # write Fwd from fIdx to frameIdxToTextPrompt[n + 1]
-                    lastFIdxFwd = frameIdxToTextPrompt[n + 1] if n < len(frameIdxToTextPrompt) - 1 else frameNumber
+                    # write Fwd from frame_idx to frame_idx_to_text_prompt[n + 1]
+                    last_frame_idx_fwd = frame_idx_to_text_prompt[n + 1] if n < len(frame_idx_to_text_prompt) - 1 else frame_number
 
-                    logger.debug(f"Extract boxes for frame Fwd from : {fIdx} to {lastFIdxFwd - 1}")
+                    logger.debug(f"Extract boxes for frame Fwd from : {frame_idx} to {last_frame_idx_fwd - 1}")
 
-                    for frameId in range(fIdx, lastFIdxFwd):
-                        colorMaskImageFwd = np.zeros_like(img)
+                    for frame_id in range(frame_idx, last_frame_idx_fwd):
+                        color_mask_image_fwd = np.zeros_like(img)
+
                         if chunk.node.outputCryptomatte.value:
                             crypto_id_fwd = np.zeros((img.shape[0], img.shape[1]), dtype=np.float32)
                             crypto_cov_fwd = np.zeros((img.shape[0], img.shape[1]), dtype=np.float32)
                             manifest_fwd = {}
-                        boxes[textPrompt]["forward"][firstFrameId + frameId] = {}
-                        for key, maskBoxProb in fwd_only[frameId].items():
-                            mask = maskBoxProb["mask"]
-                            mask_images[frameId][mask] = [(int(key) + 1) * 255, 255, 255]
-                            color = colorPalette.at(int(key)) if colorPalette.at(int(key)) is not None else [255, 255, 255]
-                            colorMaskImageFwd[mask] = [x / 255.0 for x in color]
+
+                        boxes[text_prompt]["forward"][first_frame_id + frame_id] = {}
+
+                        for key, mask_box_prob in fwd_only[frame_id].items():
+                            mask = mask_box_prob["mask"]
+                            mask_images[frame_id][mask] = [(int(key) + 1) * 255, 255, 255]
+                            color = color_palette.at(int(key)) if color_palette.at(int(key)) is not None else [255, 255, 255]
+                            color_mask_image_fwd[mask] = [x / 255.0 for x in color]
 
                             if chunk.node.outputCryptomatte.value:
-                                obj_name = f"{cryptoName}_fwd_{int(key)}"
+                                obj_name = f"{crypto_name}_fwd_{int(key)}"
                                 f32_hash, hex_val, _ = image.hash_name(obj_name)
                                 manifest_fwd[obj_name] = hex_val
                                 crypto_id_fwd[mask] = f32_hash
                                 crypto_cov_fwd[mask] = 1.0
 
-                            bbox = sam3Utils.xywhNorm2xyxy(maskBoxProb["box_xywh"], sourceInfo["w_ori"], sourceInfo["h_ori"]) # (x, y, x+w, y+h)
-                            boxes[textPrompt]["forward"][firstFrameId + frameId][key] = bbox
+                            bbox = sam3Utils.xywhNorm2xyxy(mask_box_prob["box_xywh"], source_info["w_ori"], source_info["h_ori"]) # (x, y, x+w, y+h)
+                            boxes[text_prompt]["forward"][first_frame_id + frame_id][key] = bbox
                             x1, y1, x2, y2 = bbox
                             bbox_str = str(x1) + ";" + str(y1) + ";" + str(x2) + ";" + str(y2)
-                            metadata_boxes[frameId][textPrompt]["forward"]["fwd_" + textPrompt + "_" + str(key)] = bbox_str
+                            metadata_boxes[frame_id][text_prompt]["forward"]["fwd_" + text_prompt + "_" + str(key)] = bbox_str
 
                         if chunk.node.outputColorMasks.value:
-                            outputFileColorMask = self._build_output_path(chunk, chunk_image_paths, frameId, "colorMask_" + textPrompt + "_fwd_", ".exr")
+                            output_file_color_mask = self._build_output_path(chunk, chunk_image_paths, frame_id, "colorMask_" + text_prompt + "_fwd_", ".exr")
                             optWrite = avimg.ImageWriteOptions()
                             optWrite.toColorSpace(avimg.EImageColorSpace_NO_CONVERSION)
-                            image.writeImage(outputFileColorMask, colorMaskImageFwd, sourceInfo["h_ori"], sourceInfo["w_ori"], sourceInfo["orientation"], sourceInfo["PAR"], metadata_deep_model, optWrite)
+                            image.writeImage(output_file_color_mask, color_mask_image_fwd, source_info["h_ori"], source_info["w_ori"], source_info["orientation"], source_info["PAR"], metadata_deep_model, optWrite)
 
                         if chunk.node.outputCryptomatte.value:
-                            cryptomattePath = self._build_output_path(chunk, chunk_image_paths, frameId, "cryptomatte_" + textPrompt + "_fwd_", ".exr")
-                            image.writeCryptomatte(cryptomattePath, cryptoName, img.shape[1], img.shape[0], manifest_fwd, crypto_id_fwd, crypto_cov_fwd)
+                            cryptomatte_path = self._build_output_path(chunk, chunk_image_paths, frame_id, "cryptomatte_" + text_prompt + "_fwd_", ".exr")
+                            image.writeCryptomatte(cryptomatte_path, crypto_name, img.shape[1], img.shape[0], manifest_fwd, crypto_id_fwd, crypto_cov_fwd)
 
                     if chunk.node.combineFwdAndBwdSeg.value:
-
-                        # write Bwd from frameIdxToTextPrompt[n - 1] to fIdx
-                        firstFIdxBwd = frameIdxToTextPrompt[n - 1] + 1 if n > 0 else fIdx
-                        for frameId in range(firstFIdxBwd, fIdx + 1):
-                            colorMaskImageBwd = np.zeros_like(img)
+                        # write Bwd from frame_idx_to_text_prompt[n - 1] to frame_idx
+                        first_frame_idx_bwd = frame_idx_to_text_prompt[n - 1] + 1 if n > 0 else frame_idx
+                        for frame_id in range(first_frame_idx_bwd, frame_idx + 1):
+                            color_mask_image_bwd = np.zeros_like(img)
                             if chunk.node.outputCryptomatte.value:
                                 crypto_id_bwd = np.zeros((img.shape[0], img.shape[1]), dtype=np.float32)
                                 crypto_cov_bwd = np.zeros((img.shape[0], img.shape[1]), dtype=np.float32)
                                 manifest_bwd = {}
-                            boxes[textPrompt]["backward"][firstFrameId + frameId] = {}
-                            for key, maskBoxProb in bwd_only[frameId].items():
-                                mask = maskBoxProb["mask"]
-                                mask_images[frameId][mask] = [(int(key) + 1) * 255, 255, 255]
-                                color = colorPalette.at(int(key)) if colorPalette.at(int(key)) is not None else [255, 255, 255]
-                                colorMaskImageBwd[mask] = [x / 255.0 for x in color]
+                            boxes[text_prompt]["backward"][first_frame_id + frame_id] = {}
+                            for key, mask_box_prob in bwd_only[frame_id].items():
+                                mask = mask_box_prob["mask"]
+                                mask_images[frame_id][mask] = [(int(key) + 1) * 255, 255, 255]
+                                color = color_palette.at(int(key)) if color_palette.at(int(key)) is not None else [255, 255, 255]
+                                color_mask_image_bwd[mask] = [x / 255.0 for x in color]
                                 if chunk.node.outputCryptomatte.value:
-                                    obj_name = f"{cryptoName}_bwd_{int(key)}"
+                                    obj_name = f"{crypto_name}_bwd_{int(key)}"
                                     f32_hash, hex_val, _ = image.hash_name(obj_name)
                                     manifest_bwd[obj_name] = hex_val
                                     crypto_id_bwd[mask] = f32_hash
                                     crypto_cov_bwd[mask] = 1.0
-                                bbox = sam3Utils.xywhNorm2xyxy(maskBoxProb["box_xywh"], sourceInfo["w_ori"], sourceInfo["h_ori"]) # (x, y, x+w, y+h)
-                                boxes[textPrompt]["backward"][firstFrameId + frameId][key] = bbox
+                                bbox = sam3Utils.xywhNorm2xyxy(mask_box_prob["box_xywh"], source_info["w_ori"], source_info["h_ori"]) # (x, y, x+w, y+h)
+                                boxes[text_prompt]["backward"][first_frame_id + frame_id][key] = bbox
                                 x1,y1,x2,y2 = bbox
                                 bbox_str = str(x1) + ";" + str(y1) + ";" + str(x2) + ";" + str(y2)
-                                metadata_boxes[frameId][textPrompt]["backward"]["bwd_" + textPrompt + "_" + str(key)] = bbox_str
+                                metadata_boxes[frame_id][text_prompt]["backward"]["bwd_" + text_prompt + "_" + str(key)] = bbox_str
 
                             if chunk.node.outputColorMasks.value:
-                                outputFileColorMask = self._build_output_path(chunk, chunk_image_paths, frameId, "colorMask_" + textPrompt + "_bwd_", ".png")
+                                output_file_color_mask = self._build_output_path(chunk, chunk_image_paths, frame_id, "colorMask_" + text_prompt + "_bwd_", ".png")
                                 optWrite = avimg.ImageWriteOptions()
                                 optWrite.toColorSpace(avimg.EImageColorSpace_NO_CONVERSION)
-                                image.writeImage(outputFileColorMask, colorMaskImageBwd, sourceInfo["h_ori"], sourceInfo["w_ori"], sourceInfo["orientation"], sourceInfo["PAR"], metadata_deep_model, optWrite)
+                                image.writeImage(output_file_color_mask, color_mask_image_bwd, source_info["h_ori"], source_info["w_ori"], source_info["orientation"], source_info["PAR"], metadata_deep_model, optWrite)
 
                             if chunk.node.outputCryptomatte.value:
-                                cryptomattePath = self._build_output_path(chunk, chunk_image_paths, frameId, "cryptomatte_" + textPrompt + "_bwd_", ".exr")
-                                image.writeCryptomatte(cryptomattePath, cryptoName, img.shape[1], img.shape[0], manifest_bwd, crypto_id_bwd, crypto_cov_bwd)
+                                cryptomatte_path = self._build_output_path(chunk, chunk_image_paths, frame_id, "cryptomatte_" + text_prompt + "_bwd_", ".exr")
+                                image.writeCryptomatte(cryptomatte_path, crypto_name, img.shape[1], img.shape[0], manifest_bwd, crypto_id_bwd, crypto_cov_bwd)
 
                         if n > 0:
-                            for frameId in range(firstFIdxBwd - 1, fIdx + 1):
-                                colorMaskImageMerged = np.zeros_like(img)
-                                boxes[textPrompt]["merged"][firstFrameId + frameId] = {}
-                                for key, maskBoxProb in fwd_bwd[frameId].items():
-                                    mask = maskBoxProb["mask"]
-                                    mask_images[frameId][mask] = [(int(key) + 1) * 255, 255, 255]
-                                    color = colorPalette.at(int(key)) if colorPalette.at(int(key)) is not None else [255, 255, 255]
-                                    colorMaskImageMerged[mask] = [x / 255.0 for x in color]
-                                    
-                                    bbox = sam3Utils.xywhNorm2xyxy(maskBoxProb["box_xywh"], sourceInfo["w_ori"], sourceInfo["h_ori"]) # (x, y, x+w, y+h)
-                                    boxes[textPrompt]["merged"][firstFrameId + frameId][key] = bbox
+                            for frame_id in range(first_frame_idx_bwd - 1, frame_idx + 1):
+                                color_mask_image_merged = np.zeros_like(img)
+                                boxes[text_prompt]["merged"][first_frame_id + frame_id] = {}
+                                for key, mask_box_prob in fwd_bwd[frame_id].items():
+                                    mask = mask_box_prob["mask"]
+                                    mask_images[frame_id][mask] = [(int(key) + 1) * 255, 255, 255]
+                                    color = color_palette.at(int(key)) if color_palette.at(int(key)) is not None else [255, 255, 255]
+                                    color_mask_image_merged[mask] = [x / 255.0 for x in color]
+
+                                    bbox = sam3Utils.xywhNorm2xyxy(mask_box_prob["box_xywh"], source_info["w_ori"], source_info["h_ori"]) # (x, y, x+w, y+h)
+                                    boxes[text_prompt]["merged"][first_frame_id + frame_id][key] = bbox
                                     x1,y1,x2,y2 = bbox
                                     bbox_str = str(x1) + ";" + str(y1) + ";" + str(x2) + ";" + str(y2)
-                                    metadata_boxes[frameId][textPrompt]["merged"]["merged_" + textPrompt + "_" + str(key)] = bbox_str
+                                    metadata_boxes[frame_id][text_prompt]["merged"]["merged_" + text_prompt + "_" + str(key)] = bbox_str
 
                                 if chunk.node.outputColorMasks.value:
-                                    outputFileColorMask = self._build_output_path(chunk, chunk_image_paths, frameId, "colorMask_" + textPrompt + "_merged_", ".exr")
+                                    output_file_color_mask = self._build_output_path(chunk, chunk_image_paths, frame_id, "colorMask_" + text_prompt + "_merged_", ".exr")
                                     optWrite = avimg.ImageWriteOptions()
                                     optWrite.toColorSpace(avimg.EImageColorSpace_NO_CONVERSION)
-                                    image.writeImage(outputFileColorMask, colorMaskImageMerged, sourceInfo["h_ori"], sourceInfo["w_ori"], sourceInfo["orientation"], sourceInfo["PAR"], metadata_deep_model, optWrite)
+                                    image.writeImage(output_file_color_mask, color_mask_image_merged, source_info["h_ori"], source_info["w_ori"], source_info["orientation"], source_info["PAR"], metadata_deep_model, optWrite)
 
-            prompts = [textPrompt.strip() for textPrompt in self.text_prompts if textPrompt.strip()]
+            prompts = [text_prompt.strip() for text_prompt in self.text_prompts if text_prompt.strip()]
             metadata_deep_model["Meshroom:mrSegmentation:Prompt"] = ";".join(prompts)
 
-            for frameId in range(frameNumber):
+            for frame_id in range(frame_number):
                 if chunk.node.maskInvert.value:
-                    mask = (mask_images[frameId][:,:,0:1] == 0).astype('float32')
+                    mask = (mask_images[frame_id][:, :, 0:1] == 0).astype('float32')
                 else:
-                    mask = (mask_images[frameId][:,:,0:1] > 0).astype('float32')
-                logger.info("frameId: {} - {}".format(frameId, chunk_image_paths[frameId][0]))
+                    mask = (mask_images[frame_id][:, :, 0:1] > 0).astype('float32')
+                logger.info(f"frame_id: {frame_id} - {chunk_image_paths[frame_id][0]}")
 
-                outputFileMask = self._build_output_path(chunk, chunk_image_paths, frameId, "", "." + chunk.node.extensionOut.value)
+                output_file_mask = self._build_output_path(chunk, chunk_image_paths, frame_id, "", "." + chunk.node.extensionOut.value)
                 optWrite = avimg.ImageWriteOptions()
                 optWrite.toColorSpace(avimg.EImageColorSpace_NO_CONVERSION)
 
-                if Path(outputFileMask).suffix.lower() == ".exr":
+                if Path(output_file_mask).suffix.lower() == ".exr":
                     optWrite.exrCompressionMethod(avimg.EImageExrCompression_stringToEnum("DWAA"))
                     optWrite.exrCompressionLevel(300)
 
                 frame_metadata_deep_model = dict(metadata_deep_model)
                 for prompt in self.text_prompts:
                     for direction in ["forward", "backward", "merged"]:
-                        for k, box in metadata_boxes[frameId][prompt][direction].items():
+                        for k, box in metadata_boxes[frame_id][prompt][direction].items():
                             frame_metadata_deep_model["Meshroom:mrSegmentation:" + k] = box
 
-                image.writeImage(outputFileMask, mask, sourceInfo["h_ori"], sourceInfo["w_ori"], sourceInfo["orientation"], sourceInfo["PAR"], frame_metadata_deep_model, optWrite)
+                image.writeImage(output_file_mask, mask, source_info["h_ori"], source_info["w_ori"], source_info["orientation"], source_info["PAR"], frame_metadata_deep_model, optWrite)
 
-            jsonFilename = chunk.node.output.value + "/bboxes.json"
-            with open(jsonFilename, "w", encoding="utf_8") as f:
-                json.dump(boxes, f, indent=4, ensure_ascii=False)
+            json_filename = chunk.node.output.value + "/bboxes.json"
+            with open(json_filename, "w", encoding="utf_8") as file:
+                json.dump(boxes, file, indent=4, ensure_ascii=False)
 
             video_predictor.handle_request(request=dict(type="close_session", session_id=session_id))
 

--- a/meshroom/sam3/VideoSegmentationSam3Text.py
+++ b/meshroom/sam3/VideoSegmentationSam3Text.py
@@ -142,6 +142,14 @@ from a text prompt.
             enabled=lambda node: node.outputColorMasks.value and node.combineFwdAndBwdSeg.value,
         ),
         desc.File(
+            name="colorMasksMerged",
+            label="Colored Masks Merged",
+            description="Colored segmentation masks resulting from merging forward and backward propagation. Colors correspond to instance indexes.",
+            semantic="image",
+            value=None,
+            enabled=lambda node: node.outputColorMasks.value and node.combineFwdAndBwdSeg.value,
+        ),
+        desc.File(
             name="cryptomatteFwd",
             label="Cryptomatte Forward",
             description="Cryptomatte resulting from forward propagation embedded in exr images.",
@@ -173,6 +181,7 @@ from a text prompt.
         srcFilename = "<FILESTEM>" if node.keepFilename.value else "<VIEW_ID>"
         node.colorMasksFwd.value = node.output.value + "/colorMask_" + self.textPrompts[0] + "_fwd_" + srcFilename + ".exr"
         node.colorMasksBwd.value = node.output.value + "/colorMask_" + self.textPrompts[0] + "_bwd_" + srcFilename + ".png"
+        node.colorMasksMerged.value = node.output.value + "/colorMask_" + self.textPrompts[0] + "_merged_" + srcFilename + ".exr"
         node.cryptomatteFwd.value = node.output.value + "/cryptomatte_" + self.textPrompts[0] + "_fwd_" + srcFilename + ".png"
         node.cryptomatteBwd.value = node.output.value + "/cryptomatte_" + self.textPrompts[0] + "_bwd_" + srcFilename + ".png"
 
@@ -261,19 +270,27 @@ from a text prompt.
             for textPrompt in self.textPrompts:
 
                 logger.info(f"textPrompt: {textPrompt}")
-                boxes[textPrompt] = {"forward": {}, "backward": {}}
+                boxes[textPrompt] = {"forward": {}, "backward": {}, "merged": {}}
                 cryptoName = "object" if textPrompt == "" else textPrompt
                 metadata_deep_model["Meshroom:mrSegmentation:Prompt"] = textPrompt
                 for frameId in range(frameNumber):
-                    metadata_boxes[frameId][textPrompt] = {"forward": {}, "backward": {}}
+                    metadata_boxes[frameId][textPrompt] = {"forward": {}, "backward": {}, "merged": {}}
 
                 video_predictor.handle_request(request=dict(type="reset_session", session_id=session_id))
 
                 outputs_per_frame = {}
-                outputs_per_frame_fwd = {}
-                outputs_per_frame_bwd = {}
-                max_obj_id = 0
+
+                prev_overlap_detections_fwd = {}
+                next_global_id_fwd: int = 0
+                prev_overlap_detections_bwd = {}
+                next_global_id_bwd: int = 0
+                prev_overlap_detections_merged = {}
+                next_global_id_merged: int = 0
+
                 for n, fIdx in enumerate(frameIdxToTextPrompt):
+
+                    logger.info(f"text prompt at relative frame {fIdx} (absolute frame {int(firstFrameId) + fIdx})")
+
                     video_predictor.handle_request(
                         request=dict(
                             type="add_prompt",
@@ -284,72 +301,70 @@ from a text prompt.
                     )
                     outputs_per_frame[fIdx] = sam3Utils.propagateInVideo(video_predictor, session_id, fIdx, max_frame_num_to_track, track_dir)
 
-                    max_obj_id_at_fIdx = 0
-                    for f, obj in outputs_per_frame[fIdx].items():
-                        max_obj_id_at_fIdx_f = -1
-                        if len(obj["out_obj_ids"].tolist()) > 0:
-                            max_obj_id_at_fIdx_f = max(obj["out_obj_ids"].tolist())
-                        if max_obj_id_at_fIdx_f > max_obj_id_at_fIdx:
-                            max_obj_id_at_fIdx = max_obj_id_at_fIdx_f
-                    if max_obj_id_at_fIdx > max_obj_id:
-                        max_obj_id = max_obj_id_at_fIdx
-
-                    logger.debug(f"max_obj_id = {max_obj_id}")
-
-                    colorPalette.generate_palette(max_obj_id + 1)
-
                     if n == 0:
-                        outputs_per_frame_fwd[fIdx] = outputs_per_frame[fIdx]
-                        outputs_per_frame_bwd[fIdx] = outputs_per_frame[fIdx]
+                        fwd_only = sam3Utils.prepareMasksForVisualization(outputs_per_frame[fIdx])
+                        bwd_only = sam3Utils.prepareMasksForVisualization(outputs_per_frame[fIdx])
+                        prev_overlap_detections_bwd = bwd_only[0]
+                        next_global_id_bwd = max(bwd_only[0].keys()) + 1
+                        logger.info(f"next_global_id_bwd = {next_global_id_bwd}")
                     else:
 
-                        logger.debug(f"Inputs for mapping at key frame {fIdx}")
-                        logger.debug(f"Detected Objects at frame {fIdx}:")
-                        sam3Utils.displayAt(outputs_per_frame, fIdx, fIdx, sourceInfo["w_ori"], sourceInfo["h_ori"], logger)
-                        logger.debug(f"Propagated Objects at frame {fIdx} from frame {frameIdxToTextPrompt[n - 1]}:")
-                        sam3Utils.displayAt(outputs_per_frame_fwd, frameIdxToTextPrompt[n - 1], fIdx, sourceInfo["w_ori"], sourceInfo["h_ori"], logger)
+                        track_fwd = sam3Utils.prepareMasksForVisualization(outputs_per_frame[fIdx])
+                        firstFrame = fIdx
+                        lastFrame = fIdx if n == len(frameIdxToTextPrompt) - 1 else frameIdxToTextPrompt[n + 1]
+                        fwd = {k: v for k,v in track_fwd.items() if k >= firstFrame and k <= lastFrame}
 
-                        mapping_fwd = sam3Utils.mapIds(outputs_per_frame[fIdx][fIdx], outputs_per_frame_fwd[frameIdxToTextPrompt[n - 1]][fIdx],
-                                                       logger)
-
-                        logger.debug(f"mapping fwd at key frame {fIdx}:\n{mapping_fwd}")
-
-                        outputs_per_frame_fwd[fIdx] = sam3Utils.updateSam3ObjectIds(outputs_per_frame[fIdx], mapping_fwd)
-
-                        del outputs_per_frame_fwd[frameIdxToTextPrompt[n - 1]]
-
-                        logger.debug(f"Output after mapping fwd has been applied at key frame {fIdx}")
-                        sam3Utils.displayAt(outputs_per_frame_fwd, fIdx, fIdx, sourceInfo["w_ori"], sourceInfo["h_ori"], logger)
+                        fwd_only, prev_overlap_detections_fwd, next_global_id_fwd = sam3Utils.assign_global_ids(
+                            fwd,
+                            prev_overlap_detections_fwd,
+                            next_global_id_fwd,
+                            iou_threshold=0.4,
+                            use_mask=True,
+                        )
+                        colorPalette.generate_palette(next_global_id_fwd + 1)
+                        logger.info(f"next_global_id_fwd = {next_global_id_fwd}")
 
                         if chunk.node.combineFwdAndBwdSeg.value:
 
-                            logger.debug(f"Inputs for mapping at key frame {frameIdxToTextPrompt[n - 1]}")
-                            logger.debug(f"Detected Objects at frame {frameIdxToTextPrompt[n - 1]}:")
-                            sam3Utils.displayAt(outputs_per_frame_bwd, frameIdxToTextPrompt[n - 1], frameIdxToTextPrompt[n - 1], sourceInfo["w_ori"], sourceInfo["h_ori"], logger)
-                            logger.debug(f"Propagated Objects at frame {frameIdxToTextPrompt[n - 1]} from frame {fIdx}:")
-                            sam3Utils.displayAt(outputs_per_frame, fIdx, frameIdxToTextPrompt[n - 1], sourceInfo["w_ori"], sourceInfo["h_ori"], logger)
+                            track_bwd = sam3Utils.prepareMasksForVisualization(outputs_per_frame[fIdx])
 
-                            mapping_bwd = sam3Utils.mapIds(outputs_per_frame[fIdx][frameIdxToTextPrompt[n - 1]],
-                                                           outputs_per_frame_bwd[frameIdxToTextPrompt[n - 1]][frameIdxToTextPrompt[n - 1]],
-                                                           logger)
+                            firstFrame = frameIdxToTextPrompt[n - 1]
+                            lastFrame = fIdx
+                            bwd = {k: v for k,v in track_bwd.items() if k >= firstFrame and k <= lastFrame}
 
-                            logger.debug(f"mapping bwd at key frame {frameIdxToTextPrompt[n - 1]}:\n{mapping_bwd}")
+                            bwd_only, prev_overlap_detections_bwd, next_global_id_bwd = sam3Utils.assign_global_ids(
+                                bwd,
+                                prev_overlap_detections_bwd,
+                                next_global_id_bwd,
+                                iou_threshold=0.4,
+                                use_mask=True,
+                            )
+                            colorPalette.generate_palette(next_global_id_bwd + 1)
+                            logger.info(f"next_global_id_bwd = {next_global_id_bwd}")
 
-                            outputs_per_frame_bwd[fIdx] = sam3Utils.updateSam3ObjectIds(outputs_per_frame[fIdx], mapping_bwd)
+                            track_fwd = sam3Utils.prepareMasksForVisualization(outputs_per_frame[frameIdxToTextPrompt[n - 1]])
+                            track_bwd = sam3Utils.prepareMasksForVisualization(outputs_per_frame[fIdx])
+                            firstFrame = frameIdxToTextPrompt[n - 1]
+                            lastFrame = fIdx
+                            fwd = {k: v for k,v in track_fwd.items() if k >= firstFrame and k <= lastFrame}
+                            bwd = {k: v for k,v in track_bwd.items() if k >= firstFrame and k <= lastFrame}
 
-                            del outputs_per_frame_bwd[frameIdxToTextPrompt[n - 1]]
-
-                            logger.debug(f"Output after mapping bwd has been applied at key frame {fIdx}")
-                            sam3Utils.displayAt(outputs_per_frame_bwd, fIdx, fIdx, sourceInfo["w_ori"], sourceInfo["h_ori"], logger)
+                            fwd_bwd, prev_overlap_detections_merged, next_global_id_merged = sam3Utils.merge_tracks(
+                                fwd_results=fwd,
+                                bwd_results=bwd,
+                                prev_overlap_detections=prev_overlap_detections_merged,
+                                next_global_id=next_global_id_merged,
+                                iou_threshold_merge=0.3,
+                                iou_threshold_track=0.4,
+                                use_mask=True,
+                            )
+                            colorPalette.generate_palette(next_global_id_merged + 1)
+                            logger.info(f"next_global_id_merged = {next_global_id_merged}")
 
                         del outputs_per_frame[frameIdxToTextPrompt[n - 1]]
 
-
-                    logger.debug(f"Keys: {outputs_per_frame_fwd[fIdx].keys()}")
-
                     # write Fwd from fIdx to frameIdxToTextPrompt[n + 1]
                     lastFIdxFwd = frameIdxToTextPrompt[n + 1] if n < len(frameIdxToTextPrompt) - 1 else frameNumber
-                    outputs_per_frame_visu = sam3Utils.prepareMasksForVisualization(outputs_per_frame_fwd[fIdx])
 
                     logger.debug(f"Extract boxes for frame Fwd from : {fIdx} to {lastFIdxFwd - 1}")
 
@@ -360,7 +375,7 @@ from a text prompt.
                             crypto_cov_fwd = np.zeros((img.shape[0], img.shape[1]), dtype=np.float32)
                             manifest_fwd = {}
                         boxes[textPrompt]["forward"][firstFrameId + frameId] = {}
-                        for key, maskBoxProb in outputs_per_frame_visu[frameId].items():
+                        for key, maskBoxProb in fwd_only[frameId].items():
                             mask = maskBoxProb["mask"]
                             mask_images[frameId][mask] = [(int(key) + 1) * 255, 255, 255]
                             color = colorPalette.at(int(key)) if colorPalette.at(int(key)) is not None else [255, 255, 255]
@@ -383,7 +398,7 @@ from a text prompt.
                             if chunk.node.keepFilename.value:
                                 outputFileColorMask = os.path.join(chunk.node.output.value, "colorMask_" + textPrompt + "_fwd_" + str(Path(chunk_image_paths[frameId][0]).stem) + ".exr")
                             else:
-                                outputFileColorMask = os.path.join(chunk.node.output.value, "colorMask_" + textPrompt + "_fwd_" + str(chunk_image_paths[frameId][1]) + ".png")
+                                outputFileColorMask = os.path.join(chunk.node.output.value, "colorMask_" + textPrompt + "_fwd_" + str(chunk_image_paths[frameId][1]) + ".exr")
 
                             optWrite = avimg.ImageWriteOptions()
                             optWrite.toColorSpace(avimg.EImageColorSpace_NO_CONVERSION)
@@ -402,7 +417,6 @@ from a text prompt.
 
                         # write Bwd from frameIdxToTextPrompt[n - 1] to fIdx
                         firstFIdxBwd = frameIdxToTextPrompt[n - 1] + 1 if n > 0 else fIdx
-                        outputs_per_frame_visu = sam3Utils.prepareMasksForVisualization(outputs_per_frame_bwd[fIdx])
                         for frameId in range(firstFIdxBwd, fIdx + 1):
                             colorMaskImageBwd = np.zeros_like(img)
                             if chunk.node.outputCryptomatte.value:
@@ -410,7 +424,7 @@ from a text prompt.
                                 crypto_cov_bwd = np.zeros((img.shape[0], img.shape[1]), dtype=np.float32)
                                 manifest_bwd = {}
                             boxes[textPrompt]["backward"][firstFrameId + frameId] = {}
-                            for key, maskBoxProb in outputs_per_frame_visu[frameId].items():
+                            for key, maskBoxProb in bwd_only[frameId].items():
                                 mask = maskBoxProb["mask"]
                                 mask_images[frameId][mask] = [(int(key) + 1) * 255, 255, 255]
                                 color = colorPalette.at(int(key)) if colorPalette.at(int(key)) is not None else [255, 255, 255]
@@ -446,6 +460,33 @@ from a text prompt.
 
                                 image.writeCryptomatte(cryptomattePath, cryptoName, img.shape[1], img.shape[0], manifest_bwd, crypto_id_bwd, crypto_cov_bwd)
 
+                        if n > 0:
+                            for frameId in range(firstFIdxBwd - 1, fIdx + 1):
+                                colorMaskImageMerged = np.zeros_like(img)
+                                boxes[textPrompt]["merged"][firstFrameId + frameId] = {}
+                                for key, maskBoxProb in fwd_bwd[frameId].items():
+                                    mask = maskBoxProb["mask"]
+                                    mask_images[frameId][mask] = [(int(key) + 1) * 255, 255, 255]
+                                    color = colorPalette.at(int(key)) if colorPalette.at(int(key)) is not None else [255, 255, 255]
+                                    colorMaskImageMerged[mask] = [x/255.0 for x in color]
+                                    
+                                    bbox = sam3Utils.xywhNorm2xyxy(maskBoxProb["box_xywh"], sourceInfo["w_ori"], sourceInfo["h_ori"]) # (x, y, x+w, y+h)
+                                    boxes[textPrompt]["merged"][firstFrameId + frameId][key] = bbox
+                                    x1,y1,x2,y2 = bbox
+                                    bbox_str = str(x1)+";"+str(y1)+";"+str(x2)+";"+str(y2)
+                                    metadata_boxes[frameId][textPrompt]["merged"]["merged_"+textPrompt+"_"+str(key)] = bbox_str
+
+                                if chunk.node.outputColorMasks.value:
+                                    if chunk.node.keepFilename.value:
+                                        outputFileColorMask = os.path.join(chunk.node.output.value, "colorMask_" + textPrompt + "_merged_" + str(Path(chunk_image_paths[frameId][0]).stem) + ".exr")
+                                    else:
+                                        outputFileColorMask = os.path.join(chunk.node.output.value, "colorMask_" + textPrompt + "_merged_" + str(chunk_image_paths[frameId][1]) + ".exr")
+
+                                    optWrite = avimg.ImageWriteOptions()
+                                    optWrite.toColorSpace(avimg.EImageColorSpace_NO_CONVERSION)
+
+                                    image.writeImage(outputFileColorMask, colorMaskImageMerged, sourceInfo["h_ori"], sourceInfo["w_ori"], sourceInfo["orientation"], sourceInfo["PAR"], metadata_deep_model, optWrite)
+
             prompts = [textPrompt.strip() for textPrompt in self.textPrompts if textPrompt.strip()]
             metadata_deep_model["Meshroom:mrSegmentation:Prompt"] = ";".join(prompts)
 
@@ -469,7 +510,7 @@ from a text prompt.
 
                 frame_metadata_deep_model = dict(metadata_deep_model)
                 for prompt in self.textPrompts:
-                    for direction in ["forward", "backward"]:
+                    for direction in ["forward", "backward", "merged"]:
                         for k, box in metadata_boxes[frameId][prompt][direction].items():
                             frame_metadata_deep_model["Meshroom:mrSegmentation:" + k] = box
 

--- a/meshroom/sam3/VideoSegmentationSam3Text.py
+++ b/meshroom/sam3/VideoSegmentationSam3Text.py
@@ -160,21 +160,27 @@ from a text prompt.
 
     def resolvePaths(self, node):
         import re
+
+        if node.prompt.value == "":
+            raise ValueError("Text prompt is empty.")
+
         input_path = node.input.value
         image_paths = get_image_paths_list(input_path)
         if len(image_paths) == 0:
-            raise FileNotFoundError(f'No image files found in {input_path}')
+            raise FileNotFoundError(f"No image files found in {input_path}.")
         self.image_paths = image_paths
-        if node.prompt.value == "":
-            raise ValueError(f'Text prompt is empty')
-        self.textPrompts = re.split(r'[\n]+', node.prompt.value)
-        self.textPrompts = [str(textPrompt) for textPrompt in self.textPrompts if textPrompt]
-        srcFilename = "<FILESTEM>" if node.keepFilename.value else "<VIEW_ID>"
-        node.colorMasksFwd.value = node.output.value + "/colorMask_" + self.textPrompts[0] + "_fwd_" + srcFilename + ".exr"
-        node.colorMasksBwd.value = node.output.value + "/colorMask_" + self.textPrompts[0] + "_bwd_" + srcFilename + ".png"
-        node.colorMasksMerged.value = node.output.value + "/colorMask_" + self.textPrompts[0] + "_merged_" + srcFilename + ".exr"
-        node.cryptomatteFwd.value = node.output.value + "/cryptomatte_" + self.textPrompts[0] + "_fwd_" + srcFilename + ".png"
-        node.cryptomatteBwd.value = node.output.value + "/cryptomatte_" + self.textPrompts[0] + "_bwd_" + srcFilename + ".png"
+
+        self.text_prompts = re.split(r'[\n]+', node.prompt.value)
+        self.text_prompts = [str(text_prompt) for text_prompt in self.text_prompts if text_prompt]
+        src_filename = "<FILESTEM>" if node.keepFilename.value else "<VIEW_ID>"
+        color_mask_prefix = node.output.value + "/colorMask_" + self.text_prompts[0]
+        cryptomatte_prefix = node.output.value + "/cryptomatte_" + self.text_prompts[0]
+        node.colorMasksFwd.value = color_mask_prefix + "_fwd_" + src_filename + ".exr"
+        node.colorMasksBwd.value = color_mask_prefix + "_bwd_" + src_filename + ".png"
+        node.colorMasksMerged.value = color_mask_prefix + "_merged_" + src_filename + ".exr"
+        node.cryptomatteFwd.value = cryptomatte_prefix + "_fwd_" + src_filename + ".png"
+        node.cryptomatteBwd.value = cryptomatte_prefix + "_bwd_" + src_filename + ".png"
+
 
     def processChunk(self, chunk):
         from segmentationRDS import image, sam3Utils
@@ -258,7 +264,7 @@ from a text prompt.
             for frameId in range(frameNumber):
                 metadata_boxes[frameId] = {}
 
-            for textPrompt in self.textPrompts:
+            for textPrompt in self.text_prompts:
 
                 logger.info(f"textPrompt: {textPrompt}")
                 boxes[textPrompt] = {"forward": {}, "backward": {}, "merged": {}}
@@ -480,7 +486,7 @@ from a text prompt.
 
                                     image.writeImage(outputFileColorMask, colorMaskImageMerged, sourceInfo["h_ori"], sourceInfo["w_ori"], sourceInfo["orientation"], sourceInfo["PAR"], metadata_deep_model, optWrite)
 
-            prompts = [textPrompt.strip() for textPrompt in self.textPrompts if textPrompt.strip()]
+            prompts = [textPrompt.strip() for textPrompt in self.text_prompts if textPrompt.strip()]
             metadata_deep_model["Meshroom:mrSegmentation:Prompt"] = ";".join(prompts)
 
             for frameId in range(frameNumber):
@@ -502,7 +508,7 @@ from a text prompt.
                     optWrite.exrCompressionLevel(300)
 
                 frame_metadata_deep_model = dict(metadata_deep_model)
-                for prompt in self.textPrompts:
+                for prompt in self.text_prompts:
                     for direction in ["forward", "backward", "merged"]:
                         for k, box in metadata_boxes[frameId][prompt][direction].items():
                             frame_metadata_deep_model["Meshroom:mrSegmentation:" + k] = box

--- a/meshroom/sam3/VideoSegmentationSam3Text.py
+++ b/meshroom/sam3/VideoSegmentationSam3Text.py
@@ -161,12 +161,12 @@ from a text prompt.
         ),
     ]
 
-    def _build_output_path(self, chunk, paths, frame_id, prefix, extension):
-        if chunk.node.keepFilename.value:
-            path = str(Path(paths[frame_id][0]).stem)
+    def _build_output_path(self, node, frame_id, prefix, extension):
+        if node.keepFilename.value:
+            path = str(Path(self.image_paths[frame_id][0]).stem)
         else:
-            path = str(paths[frame_id][1])
-        return os.path.join(chunk.node.output.value, prefix + path + extension)
+            path = str(self.image_paths[frame_id][1])
+        return os.path.join(node.output.value, prefix + path + extension)
 
     def _update_global_ids(self, results, prev_overlap, next_id, color_palette):
         """ Helper to assign global IDs and expand the color palette. """
@@ -206,7 +206,7 @@ from a text prompt.
 
         return frame_idx_to_text_prompt, max_frame_num_to_track, track_dir
 
-    def _load_source_images(self, chunk_image_paths):
+    def _load_source_images(self):
         """ Helper to load input images, prepare PIL frames, and extract dimensions. """
         from PIL import Image
         from segmentationRDS import image
@@ -216,7 +216,7 @@ from a text prompt.
         mask_images = []
         source_info = None
 
-        for idx, path_data in enumerate(chunk_image_paths):
+        for idx, path_data in enumerate(self.image_paths):
             img, h_ori, w_ori, PAR, orientation = image.loadImage(str(path_data[0]), True)
             pil_images.append(Image.fromarray((255.0 * img).astype("uint8")))
 
@@ -233,6 +233,112 @@ from a text prompt.
             mask_images.append(np.zeros_like(img))
 
         return pil_images, mask_images, source_info
+
+    def _export_direction_masks(
+        self,
+        node,
+        frame_range,
+        direction_name,          # "forward", "backward", "merged"
+        direction_results,       # fwd_only, bwd_only, fwd_bwd
+        text_prompt,
+        color_palette,
+        source_info,
+        state,
+        metadata_deep_model,
+        color_mask_ext,          # ".exr" or ".png"
+        write_cryptomatte=False
+    ):
+        """ Helper to process results, draw color masks, generate cryptomatte, and save outputs. """
+        from pyalicevision import image as avimg
+        from segmentationRDS import image, sam3Utils
+        import numpy as np
+
+        # Explicitly map direction names to exact legacy prefixes
+        prefix_map = {
+            "forward": "fwd",
+            "backward": "bwd",
+            "merged": "merged"
+        }
+        dir_prefix = prefix_map[direction_name]
+
+        first_frame_id = source_info["first_frame_id"]
+        crypto_name = "object" if text_prompt == "" else text_prompt
+        mask_images = state["mask_images"]
+        boxes = state["boxes"]
+        metadata_boxes = state["metadata_boxes"]
+
+        for frame_id in frame_range:
+            color_mask_image = np.zeros(source_info["shape"], dtype=source_info["dtype"])
+
+            if (first_frame_id + frame_id) not in boxes[text_prompt][direction_name]:
+                boxes[text_prompt][direction_name][first_frame_id + frame_id] = {}
+
+            output_crypto = write_cryptomatte and node.outputCryptomatte.value
+            if output_crypto:
+                crypto_id = np.zeros((source_info["h_ori"], source_info["w_ori"]), dtype=np.float32)
+                crypto_cov = np.zeros((source_info["h_ori"], source_info["w_ori"]), dtype=np.float32)
+                manifest = {}
+
+            # Get detections for current frame (if any)
+            frame_detections = direction_results.get(frame_id, {})
+
+            for key, mask_box_prob in frame_detections.items():
+                mask = mask_box_prob["mask"]
+
+                # Draw composite binary mask (for final step)
+                mask_images[frame_id][mask] = [(int(key) + 1) * 255, 255, 255]
+
+                # Draw visual color mask
+                color = color_palette.at(int(key)) if color_palette.at(int(key)) is not None else [255, 255, 255]
+                color_mask_image[mask] = [x / 255.0 for x in color]
+
+                # Process Cryptomatte hashes (matches old f"{crypto_name}_{dir_prefix}_{int(key)}")
+                if output_crypto:
+                    obj_name = f"{crypto_name}_{dir_prefix}_{int(key)}"
+                    f32_hash, hex_val, _ = image.hash_name(obj_name)
+                    manifest[obj_name] = hex_val
+                    crypto_id[mask] = f32_hash
+                    crypto_cov[mask] = 1.0
+
+                # Process Bounding Box mapping
+                bbox = sam3Utils.xywhNorm2xyxy(mask_box_prob["box_xywh"], source_info["w_ori"], source_info["h_ori"])
+                boxes[text_prompt][direction_name][first_frame_id + frame_id][key] = bbox
+
+                # Metadata writes (matches old: "fwd_" + text_prompt + "_" + str(key))
+                x1, y1, x2, y2 = bbox
+                bbox_str = f"{x1};{y1};{x2};{y2}"
+                metadata_boxes[frame_id][text_prompt][direction_name][f"{dir_prefix}_{text_prompt}_{key}"] = bbox_str
+
+            # Save color mask image
+            if node.outputColorMasks.value:
+                prefix = f"colorMask_{text_prompt}_{dir_prefix}_"
+                output_file_color_mask = self._build_output_path(node, frame_id, prefix, color_mask_ext)
+                optWrite = avimg.ImageWriteOptions()
+                optWrite.toColorSpace(avimg.EImageColorSpace_NO_CONVERSION)
+                image.writeImage(
+                    output_file_color_mask,
+                    color_mask_image,
+                    source_info["h_ori"],
+                    source_info["w_ori"],
+                    source_info["orientation"],
+                    source_info["PAR"],
+                    metadata_deep_model,
+                    optWrite
+                )
+
+            # Save Cryptomatte Multichannel EXR
+            if output_crypto:
+                prefix = f"cryptomatte_{text_prompt}_{dir_prefix}_"
+                cryptomatte_path = self._build_output_path(node, frame_id, prefix, ".exr")
+                image.writeCryptomatte(
+                    cryptomatte_path,
+                    crypto_name,
+                    source_info["w_ori"],
+                    source_info["h_ori"],
+                    manifest,
+                    crypto_id,
+                    crypto_cov
+                )
 
     def resolve_paths(self, node):
         import re
@@ -262,10 +368,8 @@ from a text prompt.
     def processChunk(self, chunk):
         from segmentationRDS import image, sam3Utils
         from sam3.model_builder import build_sam3_video_predictor
-        import numpy as np
         import torch
         from pyalicevision import image as avimg
-        from PIL import Image
         import json
 
         try:
@@ -279,9 +383,7 @@ from a text prompt.
             if not chunk.node.output.value:
                 return
 
-            logger.info("Chunk range from {} to {}".format(chunk.range.start, chunk.range.last))
-
-            chunk_image_paths = self.image_paths
+            logger.info(f"Chunk range from {chunk.range.start} to {chunk.range.last}")
 
             if not os.path.exists(chunk.node.output.value):
                 os.mkdir(chunk.node.output.value)
@@ -298,15 +400,16 @@ from a text prompt.
             mask_images = []
 
             color_palette = image.paletteGenerator()
-            first_frame_id = chunk_image_paths[0][2]
-            frame_number = len(chunk_image_paths)
+            first_frame_id = self.image_paths[0][2]
+            frame_number = len(self.image_paths)
 
             frame_idx_to_text_prompt, max_frame_num_to_track, track_dir = self._get_tracking_config(
                 chunk.node, frame_number
             )
             logger.info(f"frame_idx_to_text_prompt: {frame_idx_to_text_prompt}; direction = {track_dir}")
 
-            pil_images, mask_images, source_info = self._load_source_images(chunk_image_paths)
+            pil_images, mask_images, source_info = self._load_source_images()
+            source_info["first_frame_id"] = first_frame_id
 
             response = video_predictor.handle_request(
                 request={"type": "start_session", "resource_path": pil_images}
@@ -318,12 +421,18 @@ from a text prompt.
             for frame_id in range(frame_number):
                 metadata_boxes[frame_id] = {}
 
-            for text_prompt in self.text_prompts:
+            tracking_state = {
+                "mask_images": mask_images,
+                "boxes": boxes,
+                "metadata_boxes": metadata_boxes
+            }
 
+            for text_prompt in self.text_prompts:
                 logger.info(f"Text prompt: {text_prompt}")
+
                 boxes[text_prompt] = {"forward": {}, "backward": {}, "merged": {}}
-                crypto_name = "object" if text_prompt == "" else text_prompt
                 metadata_deep_model["Meshroom:mrSegmentation:Prompt"] = text_prompt
+
                 for frame_id in range(frame_number):
                     metadata_boxes[frame_id][text_prompt] = {"forward": {}, "backward": {}, "merged": {}}
 
@@ -422,103 +531,52 @@ from a text prompt.
 
                     logger.debug(f"Extract boxes for frame Fwd from : {frame_idx} to {last_frame_idx_fwd - 1}")
 
-                    for frame_id in range(frame_idx, last_frame_idx_fwd):
-                        color_mask_image_fwd = np.zeros(source_info["shape"], dtype=source_info["dtype"])
-
-                        if chunk.node.outputCryptomatte.value:
-                            crypto_id_fwd = np.zeros((source_info["h_ori"], source_info["w_ori"]), dtype=np.float32)
-                            crypto_cov_fwd = np.zeros((source_info["h_ori"], source_info["w_ori"]), dtype=np.float32)
-                            manifest_fwd = {}
-
-                        boxes[text_prompt]["forward"][first_frame_id + frame_id] = {}
-
-                        for key, mask_box_prob in fwd_only[frame_id].items():
-                            mask = mask_box_prob["mask"]
-                            mask_images[frame_id][mask] = [(int(key) + 1) * 255, 255, 255]
-                            color = color_palette.at(int(key)) if color_palette.at(int(key)) is not None else [255, 255, 255]
-                            color_mask_image_fwd[mask] = [x / 255.0 for x in color]
-
-                            if chunk.node.outputCryptomatte.value:
-                                obj_name = f"{crypto_name}_fwd_{int(key)}"
-                                f32_hash, hex_val, _ = image.hash_name(obj_name)
-                                manifest_fwd[obj_name] = hex_val
-                                crypto_id_fwd[mask] = f32_hash
-                                crypto_cov_fwd[mask] = 1.0
-
-                            bbox = sam3Utils.xywhNorm2xyxy(mask_box_prob["box_xywh"], source_info["w_ori"], source_info["h_ori"]) # (x, y, x+w, y+h)
-                            boxes[text_prompt]["forward"][first_frame_id + frame_id][key] = bbox
-                            x1, y1, x2, y2 = bbox
-                            bbox_str = str(x1) + ";" + str(y1) + ";" + str(x2) + ";" + str(y2)
-                            metadata_boxes[frame_id][text_prompt]["forward"]["fwd_" + text_prompt + "_" + str(key)] = bbox_str
-
-                        if chunk.node.outputColorMasks.value:
-                            output_file_color_mask = self._build_output_path(chunk, chunk_image_paths, frame_id, "colorMask_" + text_prompt + "_fwd_", ".exr")
-                            optWrite = avimg.ImageWriteOptions()
-                            optWrite.toColorSpace(avimg.EImageColorSpace_NO_CONVERSION)
-                            image.writeImage(output_file_color_mask, color_mask_image_fwd, source_info["h_ori"], source_info["w_ori"], source_info["orientation"], source_info["PAR"], metadata_deep_model, optWrite)
-
-                        if chunk.node.outputCryptomatte.value:
-                            cryptomatte_path = self._build_output_path(chunk, chunk_image_paths, frame_id, "cryptomatte_" + text_prompt + "_fwd_", ".exr")
-                            image.writeCryptomatte(cryptomatte_path, crypto_name, source_info["w_ori"], source_info["h_ori"], manifest_fwd, crypto_id_fwd, crypto_cov_fwd)
+                    self._export_direction_masks(
+                        node=chunk.node,
+                        frame_range=range(frame_idx, last_frame_idx_fwd),
+                        direction_name="forward",
+                        direction_results=fwd_only,
+                        text_prompt=text_prompt,
+                        color_palette=color_palette,
+                        source_info=source_info,
+                        state=tracking_state,
+                        metadata_deep_model=metadata_deep_model,
+                        color_mask_ext=".exr",
+                        write_cryptomatte=True
+                    )
 
                     if chunk.node.combineFwdAndBwdSeg.value:
                         # write Bwd from frame_idx_to_text_prompt[n - 1] to frame_idx
                         first_frame_idx_bwd = frame_idx_to_text_prompt[n - 1] + 1 if n > 0 else frame_idx
-                        for frame_id in range(first_frame_idx_bwd, frame_idx + 1):
-                            color_mask_image_bwd = np.zeros(source_info["shape"], dtype=source_info["dtype"])
-                            if chunk.node.outputCryptomatte.value:
-                                crypto_id_bwd = np.zeros((source_info["h_ori"], source_info["w_ori"]), dtype=np.float32)
-                                crypto_cov_bwd = np.zeros((source_info["h_ori"], source_info["w_ori"]), dtype=np.float32)
-                                manifest_bwd = {}
-                            boxes[text_prompt]["backward"][first_frame_id + frame_id] = {}
-                            for key, mask_box_prob in bwd_only[frame_id].items():
-                                mask = mask_box_prob["mask"]
-                                mask_images[frame_id][mask] = [(int(key) + 1) * 255, 255, 255]
-                                color = color_palette.at(int(key)) if color_palette.at(int(key)) is not None else [255, 255, 255]
-                                color_mask_image_bwd[mask] = [x / 255.0 for x in color]
-                                if chunk.node.outputCryptomatte.value:
-                                    obj_name = f"{crypto_name}_bwd_{int(key)}"
-                                    f32_hash, hex_val, _ = image.hash_name(obj_name)
-                                    manifest_bwd[obj_name] = hex_val
-                                    crypto_id_bwd[mask] = f32_hash
-                                    crypto_cov_bwd[mask] = 1.0
-                                bbox = sam3Utils.xywhNorm2xyxy(mask_box_prob["box_xywh"], source_info["w_ori"], source_info["h_ori"]) # (x, y, x+w, y+h)
-                                boxes[text_prompt]["backward"][first_frame_id + frame_id][key] = bbox
-                                x1,y1,x2,y2 = bbox
-                                bbox_str = str(x1) + ";" + str(y1) + ";" + str(x2) + ";" + str(y2)
-                                metadata_boxes[frame_id][text_prompt]["backward"]["bwd_" + text_prompt + "_" + str(key)] = bbox_str
 
-                            if chunk.node.outputColorMasks.value:
-                                output_file_color_mask = self._build_output_path(chunk, chunk_image_paths, frame_id, "colorMask_" + text_prompt + "_bwd_", ".png")
-                                optWrite = avimg.ImageWriteOptions()
-                                optWrite.toColorSpace(avimg.EImageColorSpace_NO_CONVERSION)
-                                image.writeImage(output_file_color_mask, color_mask_image_bwd, source_info["h_ori"], source_info["w_ori"], source_info["orientation"], source_info["PAR"], metadata_deep_model, optWrite)
-
-                            if chunk.node.outputCryptomatte.value:
-                                cryptomatte_path = self._build_output_path(chunk, chunk_image_paths, frame_id, "cryptomatte_" + text_prompt + "_bwd_", ".exr")
-                                image.writeCryptomatte(cryptomatte_path, crypto_name, source_info["w_ori"], source_info["h_ori"], manifest_bwd, crypto_id_bwd, crypto_cov_bwd)
+                        self._export_direction_masks(
+                            node=chunk.node,
+                            frame_range=range(first_frame_idx_bwd, frame_idx + 1),
+                            direction_name="backward",
+                            direction_results=bwd_only,
+                            text_prompt=text_prompt,
+                            color_palette=color_palette,
+                            source_info=source_info,
+                            state=tracking_state,
+                            metadata_deep_model=metadata_deep_model,
+                            color_mask_ext=".png",
+                            write_cryptomatte=True
+                        )
 
                         if n > 0:
-                            for frame_id in range(first_frame_idx_bwd - 1, frame_idx + 1):
-                                color_mask_image_merged = np.zeros(source_info["shape"], dtype=source_info["dtype"])
-                                boxes[text_prompt]["merged"][first_frame_id + frame_id] = {}
-                                for key, mask_box_prob in fwd_bwd[frame_id].items():
-                                    mask = mask_box_prob["mask"]
-                                    mask_images[frame_id][mask] = [(int(key) + 1) * 255, 255, 255]
-                                    color = color_palette.at(int(key)) if color_palette.at(int(key)) is not None else [255, 255, 255]
-                                    color_mask_image_merged[mask] = [x / 255.0 for x in color]
-
-                                    bbox = sam3Utils.xywhNorm2xyxy(mask_box_prob["box_xywh"], source_info["w_ori"], source_info["h_ori"]) # (x, y, x+w, y+h)
-                                    boxes[text_prompt]["merged"][first_frame_id + frame_id][key] = bbox
-                                    x1,y1,x2,y2 = bbox
-                                    bbox_str = str(x1) + ";" + str(y1) + ";" + str(x2) + ";" + str(y2)
-                                    metadata_boxes[frame_id][text_prompt]["merged"]["merged_" + text_prompt + "_" + str(key)] = bbox_str
-
-                                if chunk.node.outputColorMasks.value:
-                                    output_file_color_mask = self._build_output_path(chunk, chunk_image_paths, frame_id, "colorMask_" + text_prompt + "_merged_", ".exr")
-                                    optWrite = avimg.ImageWriteOptions()
-                                    optWrite.toColorSpace(avimg.EImageColorSpace_NO_CONVERSION)
-                                    image.writeImage(output_file_color_mask, color_mask_image_merged, source_info["h_ori"], source_info["w_ori"], source_info["orientation"], source_info["PAR"], metadata_deep_model, optWrite)
+                            self._export_direction_masks(
+                                node=chunk.node,
+                                frame_range=range(first_frame_idx_bwd - 1, frame_idx + 1),
+                                direction_name="merged",
+                                direction_results=fwd_bwd,
+                                text_prompt=text_prompt,
+                                color_palette=color_palette,
+                                source_info=source_info,
+                                state=tracking_state,
+                                metadata_deep_model=metadata_deep_model,
+                                color_mask_ext=".exr",
+                                write_cryptomatte=False
+                            )
 
             prompts = [text_prompt.strip() for text_prompt in self.text_prompts if text_prompt.strip()]
             metadata_deep_model["Meshroom:mrSegmentation:Prompt"] = ";".join(prompts)
@@ -528,9 +586,9 @@ from a text prompt.
                     mask = (mask_images[frame_id][:, :, 0:1] == 0).astype('float32')
                 else:
                     mask = (mask_images[frame_id][:, :, 0:1] > 0).astype('float32')
-                logger.info(f"frame_id: {frame_id} - {chunk_image_paths[frame_id][0]}")
+                logger.info(f"frame_id: {frame_id} - {self.image_paths[frame_id][0]}")
 
-                output_file_mask = self._build_output_path(chunk, chunk_image_paths, frame_id, "", "." + chunk.node.extensionOut.value)
+                output_file_mask = self._build_output_path(chunk.node, frame_id, "", "." + chunk.node.extensionOut.value)
                 optWrite = avimg.ImageWriteOptions()
                 optWrite.toColorSpace(avimg.EImageColorSpace_NO_CONVERSION)
 

--- a/meshroom/sam3/VideoSegmentationSam3Text.py
+++ b/meshroom/sam3/VideoSegmentationSam3Text.py
@@ -305,7 +305,8 @@ from a text prompt.
                         fwd_only = sam3Utils.prepareMasksForVisualization(outputs_per_frame[fIdx])
                         bwd_only = sam3Utils.prepareMasksForVisualization(outputs_per_frame[fIdx])
                         prev_overlap_detections_bwd = bwd_only[0]
-                        next_global_id_bwd = max(bwd_only[0].keys()) + 1
+                        if bwd_only[0].keys():
+                            next_global_id_bwd = max(bwd_only[0].keys()) + 1
                         logger.info(f"next_global_id_bwd = {next_global_id_bwd}")
                     else:
 
@@ -318,7 +319,7 @@ from a text prompt.
                             fwd,
                             prev_overlap_detections_fwd,
                             next_global_id_fwd,
-                            iou_threshold=0.4,
+                            similatity_threshold=0.4,
                             use_mask=True,
                         )
                         colorPalette.generate_palette(next_global_id_fwd + 1)
@@ -336,7 +337,7 @@ from a text prompt.
                                 bwd,
                                 prev_overlap_detections_bwd,
                                 next_global_id_bwd,
-                                iou_threshold=0.4,
+                                similatity_threshold=0.4,
                                 use_mask=True,
                             )
                             colorPalette.generate_palette(next_global_id_bwd + 1)
@@ -354,8 +355,8 @@ from a text prompt.
                                 bwd_results=bwd,
                                 prev_overlap_detections=prev_overlap_detections_merged,
                                 next_global_id=next_global_id_merged,
-                                iou_threshold_merge=0.3,
-                                iou_threshold_track=0.4,
+                                similatity_threshold_merge=0.3,
+                                similatity_threshold_track=0.4,
                                 use_mask=True,
                             )
                             colorPalette.generate_palette(next_global_id_merged + 1)

--- a/meshroom/sam3/VideoSegmentationSam3Text.py
+++ b/meshroom/sam3/VideoSegmentationSam3Text.py
@@ -315,6 +315,19 @@ from a text prompt.
                         colorPalette.generate_palette(next_global_id_bwd + 1)
                         logger.info(f"next_global_id_bwd = {next_global_id_bwd}")
 
+                        # Initialize merged tracking for n == 0 as well
+                        if chunk.node.combineFwdAndBwdSeg.value:
+                            merged_frame0_only = {fIdx: fwd_only[fIdx]}
+                            fwd_bwd, prev_overlap_detections_merged, next_global_id_merged = sam3Utils.assign_global_ids(
+                                merged_frame0_only,
+                                {},
+                                next_global_id_merged,
+                                similatity_threshold=0.4,
+                                use_mask=True,
+                            )
+                            colorPalette.generate_palette(next_global_id_merged + 1)
+                            logger.info(f"next_global_id_merged = {next_global_id_merged}")
+
                     else:
                         track_fwd = sam3Utils.prepareMasksForVisualization(outputs_per_frame[fIdx])
                         firstFrame = fIdx

--- a/meshroom/sam3/VideoSegmentationSam3Text.py
+++ b/meshroom/sam3/VideoSegmentationSam3Text.py
@@ -158,6 +158,13 @@ from a text prompt.
         ),
     ]
 
+    def _build_output_path(self, chunk, paths, frame_id, prefix, extension):
+        if chunk.node.keepFilename.value:
+            path = str(Path(paths[frame_id][0]).stem)
+        else:
+            path = str(paths[frame_id][1])
+        return os.path.join(chunk.node.output.value, prefix + path + extension)
+
     def resolvePaths(self, node):
         import re
 
@@ -416,22 +423,13 @@ from a text prompt.
                             metadata_boxes[frameId][textPrompt]["forward"]["fwd_" + textPrompt + "_" + str(key)] = bbox_str
 
                         if chunk.node.outputColorMasks.value:
-                            if chunk.node.keepFilename.value:
-                                outputFileColorMask = os.path.join(chunk.node.output.value, "colorMask_" + textPrompt + "_fwd_" + str(Path(chunk_image_paths[frameId][0]).stem) + ".exr")
-                            else:
-                                outputFileColorMask = os.path.join(chunk.node.output.value, "colorMask_" + textPrompt + "_fwd_" + str(chunk_image_paths[frameId][1]) + ".exr")
-
+                            outputFileColorMask = self._build_output_path(chunk, chunk_image_paths, frameId, "colorMask_" + textPrompt + "_fwd_", ".exr")
                             optWrite = avimg.ImageWriteOptions()
                             optWrite.toColorSpace(avimg.EImageColorSpace_NO_CONVERSION)
-
                             image.writeImage(outputFileColorMask, colorMaskImageFwd, sourceInfo["h_ori"], sourceInfo["w_ori"], sourceInfo["orientation"], sourceInfo["PAR"], metadata_deep_model, optWrite)
 
                         if chunk.node.outputCryptomatte.value:
-                            if chunk.node.keepFilename.value:
-                                cryptomattePath = os.path.join(chunk.node.output.value, "cryptomatte_" + textPrompt + "_fwd_" + str(Path(chunk_image_paths[frameId][0]).stem) + ".exr")
-                            else:
-                                cryptomattePath = os.path.join(chunk.node.output.value, "cryptomatte_" + textPrompt + "_fwd_" + str(chunk_image_paths[frameId][1]) + ".exr")
-
+                            cryptomattePath = self._build_output_path(chunk, chunk_image_paths, frameId, "cryptomatte_" + textPrompt + "_fwd_", ".exr")
                             image.writeCryptomatte(cryptomattePath, cryptoName, img.shape[1], img.shape[0], manifest_fwd, crypto_id_fwd, crypto_cov_fwd)
 
                     if chunk.node.combineFwdAndBwdSeg.value:
@@ -463,22 +461,13 @@ from a text prompt.
                                 metadata_boxes[frameId][textPrompt]["backward"]["bwd_" + textPrompt + "_" + str(key)] = bbox_str
 
                             if chunk.node.outputColorMasks.value:
-                                if chunk.node.keepFilename.value:
-                                    outputFileColorMask = os.path.join(chunk.node.output.value, "colorMask_" + textPrompt + "_bwd_" + str(Path(chunk_image_paths[frameId][0]).stem) + ".png")
-                                else:
-                                    outputFileColorMask = os.path.join(chunk.node.output.value, "colorMask_" + textPrompt + "_bwd_" + str(chunk_image_paths[frameId][1]) + ".png")
-
+                                outputFileColorMask = self._build_output_path(chunk, chunk_image_paths, frameId, "colorMask_" + textPrompt + "_bwd_", ".png")
                                 optWrite = avimg.ImageWriteOptions()
                                 optWrite.toColorSpace(avimg.EImageColorSpace_NO_CONVERSION)
-
                                 image.writeImage(outputFileColorMask, colorMaskImageBwd, sourceInfo["h_ori"], sourceInfo["w_ori"], sourceInfo["orientation"], sourceInfo["PAR"], metadata_deep_model, optWrite)
 
                             if chunk.node.outputCryptomatte.value:
-                                if chunk.node.keepFilename.value:
-                                    cryptomattePath = os.path.join(chunk.node.output.value, "cryptomatte_" + textPrompt + "_bwd_" + str(Path(chunk_image_paths[frameId][0]).stem) + ".exr")
-                                else:
-                                    cryptomattePath = os.path.join(chunk.node.output.value, "cryptomatte_" + textPrompt + "_bwd_" + str(chunk_image_paths[frameId][1]) + ".exr")
-
+                                cryptomattePath = self._build_output_path(chunk, chunk_image_paths, frameId, "cryptomatte_" + textPrompt + "_bwd_", ".exr")
                                 image.writeCryptomatte(cryptomattePath, cryptoName, img.shape[1], img.shape[0], manifest_bwd, crypto_id_bwd, crypto_cov_bwd)
 
                         if n > 0:
@@ -498,14 +487,9 @@ from a text prompt.
                                     metadata_boxes[frameId][textPrompt]["merged"]["merged_" + textPrompt + "_" + str(key)] = bbox_str
 
                                 if chunk.node.outputColorMasks.value:
-                                    if chunk.node.keepFilename.value:
-                                        outputFileColorMask = os.path.join(chunk.node.output.value, "colorMask_" + textPrompt + "_merged_" + str(Path(chunk_image_paths[frameId][0]).stem) + ".exr")
-                                    else:
-                                        outputFileColorMask = os.path.join(chunk.node.output.value, "colorMask_" + textPrompt + "_merged_" + str(chunk_image_paths[frameId][1]) + ".exr")
-
+                                    outputFileColorMask = self._build_output_path(chunk, chunk_image_paths, frameId, "colorMask_" + textPrompt + "_merged_", ".exr")
                                     optWrite = avimg.ImageWriteOptions()
                                     optWrite.toColorSpace(avimg.EImageColorSpace_NO_CONVERSION)
-
                                     image.writeImage(outputFileColorMask, colorMaskImageMerged, sourceInfo["h_ori"], sourceInfo["w_ori"], sourceInfo["orientation"], sourceInfo["PAR"], metadata_deep_model, optWrite)
 
             prompts = [textPrompt.strip() for textPrompt in self.text_prompts if textPrompt.strip()]
@@ -518,13 +502,10 @@ from a text prompt.
                     mask = (mask_images[frameId][:,:,0:1] > 0).astype('float32')
                 logger.info("frameId: {} - {}".format(frameId, chunk_image_paths[frameId][0]))
 
-                if chunk.node.keepFilename.value:
-                    outputFileMask = os.path.join(chunk.node.output.value, Path(chunk_image_paths[frameId][0]).stem + "." + chunk.node.extensionOut.value)
-                else:
-                    outputFileMask = os.path.join(chunk.node.output.value, str(chunk_image_paths[frameId][1]) + "." + chunk.node.extensionOut.value)
-
+                outputFileMask = self._build_output_path(chunk, chunk_image_paths, frameId, "", "." + chunk.node.extensionOut.value)
                 optWrite = avimg.ImageWriteOptions()
                 optWrite.toColorSpace(avimg.EImageColorSpace_NO_CONVERSION)
+
                 if Path(outputFileMask).suffix.lower() == ".exr":
                     optWrite.exrCompressionMethod(avimg.EImageExrCompression_stringToEnum("DWAA"))
                     optWrite.exrCompressionLevel(300)

--- a/meshroom/sam3/VideoSegmentationSam3Text.py
+++ b/meshroom/sam3/VideoSegmentationSam3Text.py
@@ -168,6 +168,20 @@ from a text prompt.
             path = str(paths[frame_id][1])
         return os.path.join(chunk.node.output.value, prefix + path + extension)
 
+    def _update_global_ids(self, results, prev_overlap, next_id, color_palette):
+        """ Helper to assign global IDs and expand the color palette. """
+        from segmentationRDS import sam3Utils
+
+        updated_res, next_prev_overlap, updated_id = sam3Utils.assign_global_ids(
+            results,
+            prev_overlap,
+            next_id,
+            similarity_threshold=0.4,
+            use_mask=True,
+        )
+        color_palette.generate_palette(updated_id + 1)
+        return updated_res, next_prev_overlap, updated_id
+
     def resolve_paths(self, node):
         import re
 
@@ -317,27 +331,17 @@ from a text prompt.
                         # Initialize prev_overlap_detections_bwd with global IDs
                         # by running a trivial assign_global_ids on just frame 0
                         bwd_frame0_only = {frame_idx: bwd_only[frame_idx]}
-                        _, prev_overlap_detections_bwd, next_global_id_bwd = sam3Utils.assign_global_ids(
-                            bwd_frame0_only,
-                            {},
-                            next_global_id_bwd,
-                            similarity_threshold=0.4,
-                            use_mask=True,
+                        _, prev_overlap_detections_bwd, next_global_id_bwd = self._update_global_ids(
+                            bwd_frame0_only, {}, next_global_id_bwd, color_palette
                         )
-                        colorPalette.generate_palette(next_global_id_bwd + 1)
                         logger.info(f"next_global_id_bwd = {next_global_id_bwd}")
 
                         # Initialize merged tracking for n == 0 as well
                         if chunk.node.combineFwdAndBwdSeg.value:
                             merged_frame0_only = {frame_idx: fwd_only[frame_idx]}
-                            fwd_bwd, prev_overlap_detections_merged, next_global_id_merged = sam3Utils.assign_global_ids(
-                                merged_frame0_only,
-                                {},
-                                next_global_id_merged,
-                                similarity_threshold=0.4,
-                                use_mask=True,
+                            fwd_bwd, prev_overlap_detections_merged, next_global_id_merged = self._update_global_ids(
+                                merged_frame0_only, {}, next_global_id_merged, color_palette
                             )
-                            color_palette.generate_palette(next_global_id_merged + 1)
                             logger.info(f"next_global_id_merged = {next_global_id_merged}")
 
                     else:
@@ -346,14 +350,9 @@ from a text prompt.
                         last_frame = frame_idx if n == len(frame_idx_to_text_prompt) - 1 else frame_idx_to_text_prompt[n + 1]
                         fwd = {k: v for k, v in track_fwd.items() if k >= first_frame and k <= last_frame}
 
-                        fwd_only, prev_overlap_detections_fwd, next_global_id_fwd = sam3Utils.assign_global_ids(
-                            fwd,
-                            prev_overlap_detections_fwd,
-                            next_global_id_fwd,
-                            similarity_threshold=0.4,
-                            use_mask=True,
+                        fwd_only, prev_overlap_detections_fwd, next_global_id_fwd = self._update_global_ids(
+                            fwd, prev_overlap_detections_fwd, next_global_id_fwd, color_palette
                         )
-                        color_palette.generate_palette(next_global_id_fwd + 1)
                         logger.info(f"next_global_id_fwd = {next_global_id_fwd}")
 
                         if chunk.node.combineFwdAndBwdSeg.value:
@@ -363,14 +362,9 @@ from a text prompt.
                             last_frame = frame_idx
                             bwd = {k: v for k, v in track_bwd.items() if k >= first_frame and k <= last_frame}
 
-                            bwd_only, prev_overlap_detections_bwd, next_global_id_bwd = sam3Utils.assign_global_ids(
-                                bwd,
-                                prev_overlap_detections_bwd,
-                                next_global_id_bwd,
-                                similarity_threshold=0.4,
-                                use_mask=True,
+                            bwd_only, prev_overlap_detections_bwd, next_global_id_bwd = self._update_global_ids(
+                                bwd, prev_overlap_detections_bwd, next_global_id_bwd, color_palette
                             )
-                            color_palette.generate_palette(next_global_id_bwd + 1)
                             logger.info(f"next_global_id_bwd = {next_global_id_bwd}")
 
                             # Create FRESH copies for merge_tracks since the previous calls cleared the dicts

--- a/meshroom/sam3/VideoSegmentationSam3Text.py
+++ b/meshroom/sam3/VideoSegmentationSam3Text.py
@@ -309,7 +309,7 @@ from a text prompt.
                             bwd_frame0_only,
                             {},
                             next_global_id_bwd,
-                            similatity_threshold=0.4,
+                            similarity_threshold=0.4,
                             use_mask=True,
                         )
                         colorPalette.generate_palette(next_global_id_bwd + 1)
@@ -322,7 +322,7 @@ from a text prompt.
                                 merged_frame0_only,
                                 {},
                                 next_global_id_merged,
-                                similatity_threshold=0.4,
+                                similarity_threshold=0.4,
                                 use_mask=True,
                             )
                             colorPalette.generate_palette(next_global_id_merged + 1)
@@ -338,7 +338,7 @@ from a text prompt.
                             fwd,
                             prev_overlap_detections_fwd,
                             next_global_id_fwd,
-                            similatity_threshold=0.4,
+                            similarity_threshold=0.4,
                             use_mask=True,
                         )
                         colorPalette.generate_palette(next_global_id_fwd + 1)
@@ -356,7 +356,7 @@ from a text prompt.
                                 bwd,
                                 prev_overlap_detections_bwd,
                                 next_global_id_bwd,
-                                similatity_threshold=0.4,
+                                similarity_threshold=0.4,
                                 use_mask=True,
                             )
                             colorPalette.generate_palette(next_global_id_bwd + 1)
@@ -375,8 +375,8 @@ from a text prompt.
                                 bwd_results=bwd_for_merge,
                                 prev_overlap_detections=prev_overlap_detections_merged,
                                 next_global_id=next_global_id_merged,
-                                similatity_threshold_merge=0.3,
-                                similatity_threshold_track=0.4,
+                                similarity_threshold_merge=0.3,
+                                similarity_threshold_track=0.4,
                                 use_mask=True,
                             )
                             colorPalette.generate_palette(next_global_id_merged + 1)

--- a/meshroom/videoMaMa/VideoMaMa.py
+++ b/meshroom/videoMaMa/VideoMaMa.py
@@ -146,7 +146,7 @@ class VideoMaMa(desc.Node):
                 if keepFilename:
                     filename = Path(inputFile).stem
                     if pathMask:
-                        mask_filename = "colorMask_%PROMPT%_fwd_" + str(filename)
+                        mask_filename = "colorMask_%PROMPT%_merged_" + str(filename)
                         inputFileMask = os.path.join(pathMask, mask_filename + "." + extMask)
                     outputFileMatte = os.path.join(outDir, filename + "." + extOut)
                 else:
@@ -350,14 +350,23 @@ class VideoMaMa(desc.Node):
                                 resized_h, resized_w = frame.shape[:2]
                                 mask_path = str(chunk_image_paths[frameId - firstFrameId][1])
                                 mask_path = mask_path.replace("%PROMPT%", textPrompt)
+                                colorMask = True
+                                if not os.path.exists(mask_path):
+                                    mask_path = mask_path.replace("_merged_", "_fwd_")
+                                    if not os.path.exists(mask_path):
+                                        mask_path = mask_path.replace(f"colorMask_{textPrompt}_fwd_", "")
+                                        colorMask = False
                                 mask, h_ori_mask, w_ori_mask, PAR_mask, orientation_mask = image.loadImage(mask_path, True, True, False)
-                                mask_uint8 = np.rint(np.clip(mask * 255, 0, 255)).astype(np.uint8)
-                                color_index = 0 if obj_id=="" else int(obj_id)
-                                colorPalette.generate_palette(color_index + 1)
-                                tgt = colorPalette.at(color_index)
-                                mask_id = np.zeros_like(img, dtype=np.float32)
-                                mask_id[(mask_uint8 == tgt).all(axis = -1)] = [1.0, 1.0, 1.0]
-                                imgBuf = oiio.ImageBuf(mask_id)
+                                imgBuf = oiio.ImageBuf(mask)
+                                if colorMask:
+                                    mask_uint8 = np.rint(np.clip(mask * 255, 0, 255)).astype(np.uint8)
+                                    color_index = 0 if obj_id=="" else int(obj_id)
+                                    colorPalette.generate_palette(color_index + 1)
+                                    tgt = colorPalette.at(color_index)
+                                    mask_id = np.zeros_like(img, dtype=np.float32)
+                                    mask_id[(mask_uint8 == tgt).all(axis = -1)] = [1.0, 1.0, 1.0]
+                                    imgBuf = oiio.ImageBuf(mask_id)
+                                    
                                 imgBuf = oiio.ImageBufAlgo.crop(imgBuf, roi=oiio.ROI(x1, x2, y1, y2))
                                 img_crop = imgBuf.get_pixels(format=oiio.FLOAT)
                                 if method == "resize":

--- a/segmentationRDS/sam3Utils.py
+++ b/segmentationRDS/sam3Utils.py
@@ -1,4 +1,8 @@
 import numpy as np
+from typing import Dict, Optional, Tuple
+
+FrameResults = Dict[int, Dict[int, dict]]  # {frame_idx: {obj_id: {prob, box_xywh, mask}}}
+
 
 def xywhNorm2xyxy(xywhNorm, width: int, height: int):
     # Convert a normalized rectangle (x_topLeft, y_topLeft, width, height) with all values in range [0, 1]
@@ -10,41 +14,8 @@ def xywhNorm2xyxy(xywhNorm, width: int, height: int):
     h = int(hn * height)
     return (x, y, x+w, y+h)
 
-def updateSam3ObjectIds(outputs_per_frame, mapping):
-    # Deep copy a sam3 output coming from a propagation on video
-    # Updates the object ids using mapping and return the result
-    import copy
-    import numpy as np
-    outputs_per_frame_updated = copy.deepcopy(outputs_per_frame)
-    for f, out in outputs_per_frame.items():
-        new_ids = np.zeros_like(out["out_obj_ids"])
-        for i, id in enumerate(out["out_obj_ids"]):
-            if id in mapping.keys():
-                new_ids[i] = mapping[id]
-            else:
-                new_ids[i] = id
-        outputs_per_frame_updated[f]["out_obj_ids"] = new_ids
-    return outputs_per_frame_updated
 
-def boxInterOverSmallest(xywh1, xywh2):
-    # return the ratio between the intersection area and the area of the smallest box
-    x1, y1, w1, h1 = xywh1
-    x2, y2, w2, h2 = xywh2
-    area1 = w1 * h1
-    area2 = w2 * h2
-    if area1 == 0 or area2 == 0:
-        return (0, (0, 0, 0, 0))
-    x_inter_min = max(x1, x2)
-    y_inter_min = max(y1, y2)
-    x_inter_max = min(x1 + w1, x2 + w2)
-    y_inter_max = min(y1 + h1, y2 + h2)
-    inter_w = max(0, x_inter_max - x_inter_min)
-    inter_h = max(0, y_inter_max - y_inter_min)
-    inter_area = inter_w * inter_h
-    smallest_area = min(area1, area2)
-    return (inter_area / smallest_area, (x_inter_min, y_inter_min, x_inter_max, y_inter_max))
-
-def prepareMasksForVisualization(frame_to_output):
+def prepareMasksForVisualization(frame_to_output) -> FrameResults:
     # frame_to_obj_masks --> {frame_idx: {'output_probs': np.array, `out_obj_ids`: np.array, `out_binary_masks`: np.array}}
     _processed_out = {}
     for frame_idx, out in frame_to_output.items():
@@ -53,6 +24,7 @@ def prepareMasksForVisualization(frame_to_output):
             if out["out_binary_masks"][idx].any():
                 _processed_out[frame_idx][obj_id] = {"mask": out["out_binary_masks"][idx], "box_xywh": out["out_boxes_xywh"][idx], "prob": out["out_probs"][idx]}
     return _processed_out
+
 
 def propagateInVideo(predictor, session_id, start_frame_idx=None, max_frame_num_to_track=None, direction="both"):
     # we will just propagate from frame 0 to the end of the video
@@ -69,66 +41,354 @@ def propagateInVideo(predictor, session_id, start_frame_idx=None, max_frame_num_
         outputs_per_frame[response["frame_index"]] = response["outputs"]
     return outputs_per_frame
 
-def displayAt(outputs_per_frame, keyFrameIdx, frameId, imgWidth, imageHeight, logger):
-    logger.debug(f"frame {frameId} from key frame {keyFrameIdx}:")
-    for i, obj_ids in enumerate(outputs_per_frame[keyFrameIdx][frameId]["out_obj_ids"].tolist()):
-        box = xywhNorm2xyxy(outputs_per_frame[keyFrameIdx][frameId]["out_boxes_xywh"][i], imgWidth, imageHeight)
-        prob = outputs_per_frame[keyFrameIdx][frameId]["out_probs"][i]
-        logger.debug(f"{obj_ids}: {box} ; {prob}")
 
-def mapIds(outputs_per_frame_detected, outputs_per_frame_propagated, logger):
-    import numpy as np
+def compute_mask_iou(mask_a: np.ndarray, mask_b: np.ndarray) -> float:
+    inter = np.logical_and(mask_a, mask_b).sum()
+    union = np.logical_or(mask_a, mask_b).sum()
+    return float(inter / union) if union > 0 else 0.0
 
-    ids = outputs_per_frame_detected["out_obj_ids"]
-    masks = outputs_per_frame_detected["out_binary_masks"]
-    boxes = outputs_per_frame_detected["out_boxes_xywh"]
-    idsRef = outputs_per_frame_propagated["out_obj_ids"]
-    masksRef = outputs_per_frame_propagated["out_binary_masks"]
-    boxesRef = outputs_per_frame_propagated["out_boxes_xywh"]
 
-    if len(ids) == 0 or len(masks) == 0 or len(idsRef) == 0 or len(masksRef) == 0:
-        logger.debug("mapIds: No detected or propagated objects; return empty mapping.")
-        return {}
+def compute_box_iou(box_a: np.ndarray, box_b: np.ndarray) -> float:
+    ax, ay, aw, ah = box_a
+    bx, by, bw, bh = box_b
+    ix1 = max(ax, bx)
+    iy1 = max(ay, by)
+    ix2 = min(ax + aw, bx + bw)
+    iy2 = min(ay + ah, by + bh)
+    inter = max(0.0, ix2 - ix1) * max(0.0, iy2 - iy1)
+    union = aw * ah + bw * bh - inter
+    return float(inter / union) if union > 0 else 0.0
 
-    hs, ws = masks[0].shape
 
-    logger.debug(f"{len(ids)}")
-    logger.debug(f"{ids}")
-    for k, id in enumerate(ids.tolist()):
-        logger.debug(f"{id} ; {boxes[k]}")
+def compute_similarity(det_a: dict, det_b: dict, use_mask: bool = True) -> float:
+    if use_mask and det_a["mask"] is not None and det_b["mask"] is not None:
+        iou = compute_mask_iou(det_a["mask"], det_b["mask"])
+    else:
+        iou = compute_box_iou(det_a["box_xywh"], det_b["box_xywh"])
+    prob_score = (det_a["prob"] + det_b["prob"]) / 2.0
+    return 0.7 * iou + 0.3 * prob_score
 
-    mapping = {}
-    for d, id_det in enumerate(ids.tolist()):
-        obj_id_min = -1
-        iou_max = 0
-        ios_best = 0
-        for p, id_prop in enumerate(idsRef.tolist()):
-            inter_over_smallest, box_inter = boxInterOverSmallest(boxes[d], boxesRef[p])
-            logger.debug(f"{id_det} vs {id_prop}: ios = {inter_over_smallest} ({ios_best})")
-            if  inter_over_smallest > 0.9:
-                x1, y1, x2, y2 = box_inter
-                x1 = int(x1 * ws)
-                y1 = int(y1 * hs)
-                x2 = int(x2 * ws)
-                y2 = int(y2 * hs)
-                crop = masks[d][y1:y2, x1:x2]
-                cropRef = masksRef[p][y1:y2, x1:x2]
-                inter = np.logical_and(crop,cropRef).sum()
-                union = np.logical_or(crop,cropRef).sum()
-                iou = 0 if union == 0 else inter / union
-                logger.debug(f"{id_det} vs {id_prop}: iou = {iou} ({iou_max})")
-                if iou > iou_max:
-                    iou_max = iou
-                    if iou > 0.7:
-                        obj_id_min = id_prop
-                        ios_best = inter_over_smallest
-        mapping[id_det] = obj_id_min
 
-    if -1 in mapping.values():
-        for idSrc in mapping:
-            if mapping[idSrc] == -1:
-                if idSrc in mapping.values():
-                    mapping[idSrc] = max(mapping.values()) + 1
-                else:
-                    mapping[idSrc] = idSrc
-    return mapping
+def match_detections(
+    src_a: Dict[int, dict],
+    src_b: Dict[int, dict],
+    iou_threshold: float = 0.3,
+    use_mask: bool = True,
+) -> Tuple[Dict[int, int], list, list]:
+    """
+    Match objects from src_a to src_b using the Hungarian algorithm.
+
+    Returns:
+        matches     : {id_a -> id_b}
+        unmatched_a : ids in src_a with no match
+        unmatched_b : ids in src_b with no match
+    """
+    from scipy.optimize import linear_sum_assignment
+
+    ids_a = list(src_a.keys())
+    ids_b = list(src_b.keys())
+
+    if not ids_a or not ids_b:
+        return {}, list(ids_a), list(ids_b)
+
+    cost = np.array(
+        [
+            [1.0 - compute_similarity(src_a[a], src_b[b], use_mask) for b in ids_b]
+            for a in ids_a
+        ],
+        dtype=np.float32,
+    )
+
+    row_ind, col_ind = linear_sum_assignment(cost)
+
+    matches = {}
+    unmatched_a = list(ids_a)
+    unmatched_b = list(ids_b)
+
+    for r, c in zip(row_ind, col_ind):
+        if cost[r, c] < (1.0 - iou_threshold):
+            a, b = ids_a[r], ids_b[c]
+            matches[a] = b
+            unmatched_a.remove(a)
+            unmatched_b.remove(b)
+
+    return matches, unmatched_a, unmatched_b
+
+
+def merge_two_detections(det_fwd: Optional[dict], det_bwd: Optional[dict]) -> dict:
+    """
+    Merge two detections for the same instance on the same frame.
+    If only one is available, return it as-is.
+    """
+    if det_fwd is None:
+        return det_bwd
+    if det_bwd is None:
+        return det_fwd
+
+    prob = max(det_fwd["prob"], det_bwd["prob"])
+
+    w_f = det_fwd["prob"] / (det_fwd["prob"] + det_bwd["prob"] + 1e-8)
+    w_b = 1.0 - w_f
+
+    if det_fwd["mask"] is not None and det_bwd["mask"] is not None:
+        score = (
+            w_f * det_fwd["mask"].astype(np.float32)
+            + w_b * det_bwd["mask"].astype(np.float32)
+        )
+        mask = (score > 0.5).astype(bool)
+    else:
+        mask = det_fwd["mask"] if det_fwd["mask"] is not None else det_bwd["mask"]
+
+    box = w_f * det_fwd["box_xywh"] + w_b * det_bwd["box_xywh"]
+
+    return {"prob": prob, "box_xywh": box, "mask": mask}
+
+
+def merge_chunk_forward_backward(
+    fwd_results: FrameResults,
+    bwd_results: FrameResults,
+    iou_threshold: float = 0.3,
+    use_mask: bool = True,
+) -> FrameResults:
+    """
+    Merge forward and backward results for the same chunk.
+
+    - Forward IDs are used as the local reference IDs.
+    - Objects seen only in backward receive a temporary negative local ID.
+    - The bwd->fwd mapping is stabilised by majority vote across all frames.
+    """
+    all_frames = sorted(set(fwd_results) | set(bwd_results))
+
+    # Build a stable bwd_id -> fwd_id mapping via majority vote over all frames
+    votes: Dict[int, Dict[int, int]] = {}  # {bwd_id: {fwd_id: count}}
+
+    for frame_idx in all_frames:
+        fwd_frame = fwd_results.get(frame_idx, {})
+        bwd_frame = bwd_results.get(frame_idx, {})
+        matches, _, _ = match_detections(fwd_frame, bwd_frame, iou_threshold, use_mask)
+        for fwd_id, bwd_id in matches.items():
+            votes.setdefault(bwd_id, {})
+            votes[bwd_id][fwd_id] = votes[bwd_id].get(fwd_id, 0) + 1
+
+    bwd_to_fwd: Dict[int, int] = {
+        bwd_id: max(fwd_votes, key=fwd_votes.get)
+        for bwd_id, fwd_votes in votes.items()
+    }
+
+    # Frame-by-frame fusion
+    bwd_only_map: Dict[int, int] = {}
+    next_bwd_only_id = -1
+    merged: FrameResults = {}
+
+    for frame_idx in all_frames:
+        fwd_frame = fwd_results.get(frame_idx, {})
+        bwd_frame = bwd_results.get(frame_idx, {})
+        merged_frame: Dict[int, dict] = {}
+        seen_fwd_ids = set()
+
+        for bwd_id, det_b in bwd_frame.items():
+            if bwd_id in bwd_to_fwd:
+                fwd_id = bwd_to_fwd[bwd_id]
+                merged_frame[fwd_id] = merge_two_detections(fwd_frame.get(fwd_id), det_b)
+                seen_fwd_ids.add(fwd_id)
+            else:
+                # Object seen only in backward pass
+                if bwd_id not in bwd_only_map:
+                    bwd_only_map[bwd_id] = next_bwd_only_id
+                    next_bwd_only_id -= 1
+                merged_frame[bwd_only_map[bwd_id]] = det_b
+
+        for fwd_id, det_f in fwd_frame.items():
+            if fwd_id not in seen_fwd_ids:
+                merged_frame[fwd_id] = det_f
+
+        merged[frame_idx] = merged_frame
+
+    return merged
+
+
+def merge_overlap_frame(
+    prev_det: Dict[int, dict],  # global IDs — from the previous chunk
+    curr_det: Dict[int, dict],  # local  IDs — from the current chunk
+    iou_threshold: float = 0.4,
+    use_mask: bool = True,
+) -> Tuple[Dict[int, int], Dict[int, dict], Dict[int, int]]:
+    """
+    Resolve the shared overlap frame between two consecutive chunks.
+
+    The overlap frame has been produced twice:
+      - once as the *last*  frame of chunk k-1  (global IDs, already finalised)
+      - once as the *first* frame of chunk k    (local  IDs, to be mapped)
+
+    This function:
+      1. Matches local IDs to global IDs on the overlap frame.
+      2. Merges the two detections for matched objects.
+      3. Returns the local->global ID mapping to be applied to the whole chunk.
+
+    Args:
+        prev_det      : {global_id: det} — overlap frame from previous chunk
+        curr_det      : {local_id:  det} — overlap frame from current chunk
+        iou_threshold : minimum similarity to accept a match
+
+    Returns:
+        local_to_global   : {local_id -> global_id} for matched objects
+        merged_overlap    : {global_id: det} — merged detections on the overlap frame
+        unmatched_local   : {local_id -> None} for unmatched local objects
+                            (they will receive a new global ID later)
+    """
+    matches, unmatched_local_ids, unmatched_prev_ids = match_detections(
+        curr_det,   # src_a : local IDs
+        prev_det,   # src_b : global IDs
+        iou_threshold,
+        use_mask,
+    )
+    # matches : {local_id -> global_id}
+
+    local_to_global: Dict[int, int] = dict(matches)
+
+    # Merge detections on the overlap frame for matched objects
+    merged_overlap: Dict[int, dict] = {}
+
+    for local_id, global_id in matches.items():
+        merged_overlap[global_id] = merge_two_detections(
+            curr_det[local_id], prev_det[global_id]
+        )
+
+    # Objects present in prev chunk but not matched — keep them from previous result
+    for global_id in unmatched_prev_ids:
+        merged_overlap[global_id] = prev_det[global_id]
+
+    # Objects present only in current chunk on the overlap frame —
+    # local_id kept as sentinel (None value); global ID assigned in step 3
+    unmatched_local: Dict[int, None] = {lid: None for lid in unmatched_local_ids}
+
+    return local_to_global, merged_overlap, unmatched_local
+
+
+def assign_global_ids(
+    chunk_merged: FrameResults,
+    prev_overlap_detections: Dict[int, dict],
+    next_global_id: int,
+    iou_threshold: float = 0.4,
+    use_mask: bool = True,
+) -> Tuple[FrameResults, Dict[int, dict], int]:
+    """
+    Replace local IDs in the merged chunk with globally consistent IDs,
+    taking into account the 1-frame overlap with the previous chunk.
+
+    The overlap frame (first frame of the current chunk == last frame of the
+    previous chunk) is re-merged with the already-finalised previous result.
+
+    Args:
+        chunk_merged             : output of merge_chunk_forward_backward
+        prev_overlap_detections  : {global_id: det} of the overlap frame
+                                   from the previous chunk (empty for chunk 0)
+        next_global_id           : next available global ID
+
+    Returns:
+        global_chunk        : {frame_idx: {global_id: det}}
+        new_overlap_frame   : {global_id: det} of the last frame of this chunk
+                              (to be passed as prev_overlap_detections for chunk k+1)
+        next_global_id      : updated counter
+    """
+    all_frames = sorted(chunk_merged.keys())
+    overlap_frame_idx = all_frames[0]   # shared with previous chunk
+    overlap_det_curr  = chunk_merged[overlap_frame_idx]
+
+    # ── Resolve the overlap frame ────────────────────────────────────────────
+    local_to_global, merged_overlap, unmatched_local = merge_overlap_frame(
+        prev_overlap_detections,
+        overlap_det_curr,
+        iou_threshold,
+        use_mask,
+    )
+
+    # Assign new global IDs to unmatched local objects and insert them directly
+    # into merged_overlap — no temporary IDs, no collision risk.
+    for local_id in unmatched_local:
+        local_to_global[local_id] = next_global_id
+        merged_overlap[next_global_id] = overlap_det_curr[local_id]
+        next_global_id += 1
+
+    # ── Remap every frame of the chunk ──────────────────────────────────────
+    global_chunk: FrameResults = {}
+
+    for frame_idx in all_frames:
+        if frame_idx == overlap_frame_idx:
+            # Use the already-merged overlap frame
+            global_chunk[frame_idx] = merged_overlap
+            continue
+
+        global_frame: Dict[int, dict] = {}
+        for local_id, det in chunk_merged[frame_idx].items():
+            if local_id not in local_to_global:
+                # Object that appeared after the overlap frame
+                local_to_global[local_id] = next_global_id
+                next_global_id += 1
+            global_frame[local_to_global[local_id]] = det
+        global_chunk[frame_idx] = global_frame
+
+    # Last frame of this chunk becomes the overlap frame for the next chunk
+    new_overlap_frame = dict(global_chunk[all_frames[-1]])
+
+    return global_chunk, new_overlap_frame, next_global_id
+
+
+def merge_tracks(
+    fwd_results: FrameResults,
+    bwd_results: FrameResults,
+    prev_overlap_detections: Dict[int, dict],
+    next_global_id: int,
+    iou_threshold_merge: float = 0.3,
+    iou_threshold_track: float = 0.4,
+    use_mask: bool = True,
+) -> Tuple[FrameResults, Dict[int, dict], int]:
+    """
+    Process a single chunk end-to-end:
+      1. Merge forward and backward results.
+      2. Assign globally consistent IDs, resolving the overlap frame.
+      3. Free intermediate data.
+
+    Chunk layout (N=4, overlap=1):
+
+        chunk k-1 : [f0  f1  f2  f3]
+        chunk k   :             [f3  f4  f5  f6]
+                                 ^^^ overlap frame
+
+    Args:
+        fwd_results              : {frame_idx: {local_id: det}}  — forward pass
+        bwd_results              : {frame_idx: {local_id: det}}  — backward pass
+        prev_overlap_detections  : {global_id: det} of the last frame of chunk k-1
+                                   (empty dict for the very first chunk)
+        next_global_id           : next available global ID (0 for the first chunk)
+
+    Returns:
+        global_chunk        : {frame_idx: {global_id: det}}
+                              includes the overlap frame with merged detections
+        new_overlap_frame   : {global_id: det} — last frame of this chunk,
+                              to be passed as prev_overlap_detections for chunk k+1
+        next_global_id      : updated, to be passed to the next call
+    """
+    # Step 1 — fuse forward and backward within the chunk
+    chunk_merged = merge_chunk_forward_backward(
+        fwd_results,
+        bwd_results,
+        iou_threshold=iou_threshold_merge,
+        use_mask=use_mask,
+    )
+    fwd_results.clear()
+    bwd_results.clear()
+
+    # Step 2 — assign global IDs, handle overlap frame
+    global_chunk, new_overlap_frame, next_global_id = assign_global_ids(
+        chunk_merged,
+        prev_overlap_detections,
+        next_global_id,
+        iou_threshold=iou_threshold_track,
+        use_mask=use_mask,
+    )
+    chunk_merged.clear()
+
+    return global_chunk, new_overlap_frame, next_global_id
+
+    

--- a/segmentationRDS/sam3Utils.py
+++ b/segmentationRDS/sam3Utils.py
@@ -72,7 +72,7 @@ def compute_similarity(det_a: dict, det_b: dict, use_mask: bool = True) -> float
 def match_detections(
     src_a: Dict[int, dict],
     src_b: Dict[int, dict],
-    iou_threshold: float = 0.3,
+    similatity_threshold: float = 0.3,
     use_mask: bool = True,
 ) -> Tuple[Dict[int, int], list, list]:
     """
@@ -106,7 +106,7 @@ def match_detections(
     unmatched_b = list(ids_b)
 
     for r, c in zip(row_ind, col_ind):
-        if cost[r, c] < (1.0 - iou_threshold):
+        if cost[r, c] < (1.0 - similatity_threshold):
             a, b = ids_a[r], ids_b[c]
             matches[a] = b
             unmatched_a.remove(a)
@@ -147,7 +147,7 @@ def merge_two_detections(det_fwd: Optional[dict], det_bwd: Optional[dict]) -> di
 def merge_chunk_forward_backward(
     fwd_results: FrameResults,
     bwd_results: FrameResults,
-    iou_threshold: float = 0.3,
+    similatity_threshold: float = 0.3,
     use_mask: bool = True,
 ) -> FrameResults:
     """
@@ -165,7 +165,7 @@ def merge_chunk_forward_backward(
     for frame_idx in all_frames:
         fwd_frame = fwd_results.get(frame_idx, {})
         bwd_frame = bwd_results.get(frame_idx, {})
-        matches, _, _ = match_detections(fwd_frame, bwd_frame, iou_threshold, use_mask)
+        matches, _, _ = match_detections(fwd_frame, bwd_frame, similatity_threshold, use_mask)
         for fwd_id, bwd_id in matches.items():
             votes.setdefault(bwd_id, {})
             votes[bwd_id][fwd_id] = votes[bwd_id].get(fwd_id, 0) + 1
@@ -210,7 +210,7 @@ def merge_chunk_forward_backward(
 def merge_overlap_frame(
     prev_det: Dict[int, dict],  # global IDs — from the previous chunk
     curr_det: Dict[int, dict],  # local  IDs — from the current chunk
-    iou_threshold: float = 0.4,
+    similatity_threshold: float = 0.4,
     use_mask: bool = True,
 ) -> Tuple[Dict[int, int], Dict[int, dict], Dict[int, int]]:
     """
@@ -228,7 +228,7 @@ def merge_overlap_frame(
     Args:
         prev_det      : {global_id: det} — overlap frame from previous chunk
         curr_det      : {local_id:  det} — overlap frame from current chunk
-        iou_threshold : minimum similarity to accept a match
+        similatity_threshold : minimum similarity to accept a match
 
     Returns:
         local_to_global   : {local_id -> global_id} for matched objects
@@ -239,7 +239,7 @@ def merge_overlap_frame(
     matches, unmatched_local_ids, unmatched_prev_ids = match_detections(
         curr_det,   # src_a : local IDs
         prev_det,   # src_b : global IDs
-        iou_threshold,
+        similatity_threshold,
         use_mask,
     )
     # matches : {local_id -> global_id}
@@ -269,7 +269,7 @@ def assign_global_ids(
     chunk_merged: FrameResults,
     prev_overlap_detections: Dict[int, dict],
     next_global_id: int,
-    iou_threshold: float = 0.4,
+    similatity_threshold: float = 0.4,
     use_mask: bool = True,
 ) -> Tuple[FrameResults, Dict[int, dict], int]:
     """
@@ -292,6 +292,8 @@ def assign_global_ids(
         next_global_id      : updated counter
     """
     all_frames = sorted(chunk_merged.keys())
+    if not all_frames:
+        return {}, dict(prev_overlap_detections), next_global_id
     overlap_frame_idx = all_frames[0]   # shared with previous chunk
     overlap_det_curr  = chunk_merged[overlap_frame_idx]
 
@@ -299,7 +301,7 @@ def assign_global_ids(
     local_to_global, merged_overlap, unmatched_local = merge_overlap_frame(
         prev_overlap_detections,
         overlap_det_curr,
-        iou_threshold,
+        similatity_threshold,
         use_mask,
     )
 
@@ -339,8 +341,8 @@ def merge_tracks(
     bwd_results: FrameResults,
     prev_overlap_detections: Dict[int, dict],
     next_global_id: int,
-    iou_threshold_merge: float = 0.3,
-    iou_threshold_track: float = 0.4,
+    similatity_threshold_merge: float = 0.3,
+    similatity_threshold_track: float = 0.4,
     use_mask: bool = True,
 ) -> Tuple[FrameResults, Dict[int, dict], int]:
     """
@@ -373,7 +375,7 @@ def merge_tracks(
     chunk_merged = merge_chunk_forward_backward(
         fwd_results,
         bwd_results,
-        iou_threshold=iou_threshold_merge,
+        similatity_threshold=similatity_threshold_merge,
         use_mask=use_mask,
     )
     fwd_results.clear()
@@ -384,7 +386,7 @@ def merge_tracks(
         chunk_merged,
         prev_overlap_detections,
         next_global_id,
-        iou_threshold=iou_threshold_track,
+        similatity_threshold=similatity_threshold_track,
         use_mask=use_mask,
     )
     chunk_merged.clear()

--- a/segmentationRDS/sam3Utils.py
+++ b/segmentationRDS/sam3Utils.py
@@ -72,7 +72,7 @@ def compute_similarity(det_a: dict, det_b: dict, use_mask: bool = True) -> float
 def match_detections(
     src_a: Dict[int, dict],
     src_b: Dict[int, dict],
-    similatity_threshold: float = 0.3,
+    similarity_threshold: float = 0.3,
     use_mask: bool = True,
 ) -> Tuple[Dict[int, int], list, list]:
     """
@@ -106,7 +106,7 @@ def match_detections(
     unmatched_b = list(ids_b)
 
     for r, c in zip(row_ind, col_ind):
-        if cost[r, c] < (1.0 - similatity_threshold):
+        if cost[r, c] < (1.0 - similarity_threshold):
             a, b = ids_a[r], ids_b[c]
             matches[a] = b
             unmatched_a.remove(a)
@@ -147,7 +147,7 @@ def merge_two_detections(det_fwd: Optional[dict], det_bwd: Optional[dict]) -> di
 def merge_chunk_forward_backward(
     fwd_results: FrameResults,
     bwd_results: FrameResults,
-    similatity_threshold: float = 0.3,
+    similarity_threshold: float = 0.3,
     use_mask: bool = True,
 ) -> FrameResults:
     """
@@ -165,7 +165,7 @@ def merge_chunk_forward_backward(
     for frame_idx in all_frames:
         fwd_frame = fwd_results.get(frame_idx, {})
         bwd_frame = bwd_results.get(frame_idx, {})
-        matches, _, _ = match_detections(fwd_frame, bwd_frame, similatity_threshold, use_mask)
+        matches, _, _ = match_detections(fwd_frame, bwd_frame, similarity_threshold, use_mask)
         for fwd_id, bwd_id in matches.items():
             votes.setdefault(bwd_id, {})
             votes[bwd_id][fwd_id] = votes[bwd_id].get(fwd_id, 0) + 1
@@ -210,7 +210,7 @@ def merge_chunk_forward_backward(
 def merge_overlap_frame(
     prev_det: Dict[int, dict],  # global IDs — from the previous chunk
     curr_det: Dict[int, dict],  # local  IDs — from the current chunk
-    similatity_threshold: float = 0.4,
+    similarity_threshold: float = 0.4,
     use_mask: bool = True,
 ) -> Tuple[Dict[int, int], Dict[int, dict], Dict[int, int]]:
     """
@@ -228,7 +228,7 @@ def merge_overlap_frame(
     Args:
         prev_det      : {global_id: det} — overlap frame from previous chunk
         curr_det      : {local_id:  det} — overlap frame from current chunk
-        similatity_threshold : minimum similarity to accept a match
+        similarity_threshold : minimum similarity to accept a match
 
     Returns:
         local_to_global   : {local_id -> global_id} for matched objects
@@ -239,7 +239,7 @@ def merge_overlap_frame(
     matches, unmatched_local_ids, unmatched_prev_ids = match_detections(
         curr_det,   # src_a : local IDs
         prev_det,   # src_b : global IDs
-        similatity_threshold,
+        similarity_threshold,
         use_mask,
     )
     # matches : {local_id -> global_id}
@@ -269,7 +269,7 @@ def assign_global_ids(
     chunk_merged: FrameResults,
     prev_overlap_detections: Dict[int, dict],
     next_global_id: int,
-    similatity_threshold: float = 0.4,
+    similarity_threshold: float = 0.4,
     use_mask: bool = True,
 ) -> Tuple[FrameResults, Dict[int, dict], int]:
     """
@@ -301,7 +301,7 @@ def assign_global_ids(
     local_to_global, merged_overlap, unmatched_local = merge_overlap_frame(
         prev_overlap_detections,
         overlap_det_curr,
-        similatity_threshold,
+        similarity_threshold,
         use_mask,
     )
 
@@ -341,8 +341,8 @@ def merge_tracks(
     bwd_results: FrameResults,
     prev_overlap_detections: Dict[int, dict],
     next_global_id: int,
-    similatity_threshold_merge: float = 0.3,
-    similatity_threshold_track: float = 0.4,
+    similarity_threshold_merge: float = 0.3,
+    similarity_threshold_track: float = 0.4,
     use_mask: bool = True,
 ) -> Tuple[FrameResults, Dict[int, dict], int]:
     """
@@ -375,7 +375,7 @@ def merge_tracks(
     chunk_merged = merge_chunk_forward_backward(
         fwd_results,
         bwd_results,
-        similatity_threshold=similatity_threshold_merge,
+        similarity_threshold=similarity_threshold_merge,
         use_mask=use_mask,
     )
     fwd_results.clear()
@@ -386,11 +386,9 @@ def merge_tracks(
         chunk_merged,
         prev_overlap_detections,
         next_global_id,
-        similatity_threshold=similatity_threshold_track,
+        similarity_threshold=similarity_threshold_track,
         use_mask=use_mask,
     )
     chunk_merged.clear()
 
     return global_chunk, new_overlap_frame, next_global_id
-
-    


### PR DESCRIPTION
This pull request introduces support for generating and handling merged colored segmentation masks in the video segmentation pipeline. The main focus is on producing, saving, and propagating segmentation masks that result from merging forward and backward propagation, and ensuring downstream consumers use these merged masks as the default. Several code paths are updated to facilitate this new output, including mask generation, file naming, and metadata handling.

**VideoSegmentationSam3Text pipeline enhancements:**

* Added a new output file (`colorMasksMerged`) to store merged colored segmentation masks, including path resolution and file writing logic.
* Updated the mask processing logic to compute, assign, and save merged tracks using `sam3Utils.merge_tracks`, with appropriate color palette generation and metadata annotation.
* Ensured merged mask outputs use `.exr` format consistently, aligning with forward mask outputs.

**Video Mating integration:**

* Changed Video Matting to use merged colored masks as the default input, falling back to forward masks if merged masks are not available. Updated path resolution and loading logic accordingly.

These changes ensure more robust and accurate mask handling in both mask generation and downstream processing, improving segmentation quality and consistency.