### PR TITLE
[sam3] `VideoSegmentationSam3`: Fix missing label for `Shape` attribute

### DIFF
--- a/meshroom/sam3/VideoSegmentationSam3.py
+++ b/meshroom/sam3/VideoSegmentationSam3.py
@@ -132,6 +132,7 @@ In order to associate a point to a given submask, it must be colored with the su
         ),
         desc.Rectangle(
             name="boxPrompt",
+            label="Box Prompt",
             description="Single bounding box used as initial prompt.",
             keyable=True,
             keyType="viewId"


### PR DESCRIPTION
`Shape` attributes still require the `label` field to be filled. 