### PR TITLE
[sam3] `VideoSegmentationSam3Text`: Fix multi-prompt support and binary mask writing

### DIFF
--- a/meshroom/sam3/VideoSegmentationSam3Text.py
+++ b/meshroom/sam3/VideoSegmentationSam3Text.py
@@ -321,10 +321,6 @@ cryptomatte from a text prompt.
                 mask = mask_box_prob["mask"]
                 masks.append(mask.squeeze())
 
-                # Write binary mask corresponding to the definitive pass (forward if no merging, merged otherwise)
-                if is_definitive:
-                    mask_images[frame_id][mask] = [(int(key) + 1) * 255, 255, 255]
-
                 # Draw visual color mask
                 color = color_palette.at(int(key)) if color_palette.at(int(key)) is not None else [255, 255, 255]
                 color_mask_image[mask] = [x / 255.0 for x in color]
@@ -353,7 +349,7 @@ cryptomatte from a text prompt.
                     ks = node.bondingKernelSize.value
                     mask_global = np.expand_dims(sam3Utils.bond_masks(masks, ks, ks, ks), axis=-1)
                 if is_definitive:
-                    mask_images[frame_id] = mask_global
+                    mask_images[frame_id] = np.maximum(mask_images[frame_id], mask_global)
 
 
             # Save color mask image


### PR DESCRIPTION
This PR fixes the update of the binary masks, which solves two different problems at once:
- in some cases, depending on the input images, the binary masks could fail to be written because their shape was initially defined to match with said input images, but did not in the end, causing an interruption of the `processChunk` function.
- using several prompts at once (separated with a line return) was not working correctly, as prompts were overwriting one another as the iteration was going along. 

Both issues are solved by the change proposed in this PR. Additionally, we remove some initialisation for the binary masks that was not useful anymore, as the masks are consistently written if the condition is met.

