### PR TITLE
Update bbox chunks recovery in `VideoMatting`

### DIFF
--- a/meshroom/videoMatting/VideoMatting.py
+++ b/meshroom/videoMatting/VideoMatting.py
@@ -295,6 +295,8 @@ Matting node for video sequences.
                 metadata_boxes[first_frame_id + frame_id] = {}
 
             logger.debug(f"bboxes.keys() = {bboxes.keys()}")
+            prompts = [key.rsplit('_', 1)[0] for key in bboxes.keys()]
+            metadata_deep_model_base["Meshroom:mrSegmentation:Prompt"] = ";".join(list(dict.fromkeys(prompts)))
 
             full_alpha = {}
             img, h_ori, w_ori, p_a_r, orientation = image.loadImage(str(chunk_image_paths[0][0]), True)

--- a/segmentationRDS/bboxUtils.py
+++ b/segmentationRDS/bboxUtils.py
@@ -217,38 +217,28 @@ def extract_tracking(
 
     for label, directions in data.items():
         forward  = directions.get("forward",  {})
-        backward = directions.get("backward", {})
+        merged = directions.get("merged", {})
 
         all_object_ids = set()
-        for frame_data in forward.values():
-            all_object_ids.update(frame_data.keys())
-        for frame_data in backward.values():
-            all_object_ids.update(frame_data.keys())
+        if merged:
+            for frame_data in merged.values():
+                all_object_ids.update(frame_data.keys())
+        else:
+            for frame_data in forward.values():
+                all_object_ids.update(frame_data.keys())
 
         for obj_id in sorted(all_object_ids, key=int):
             key = f"{label}_{obj_id}"
             raw_boxes = {}
 
-            all_frames = sorted(
-                set(forward.keys()) | set(backward.keys()),
-                key=int
-            )
-
-            # Merge forward/backward (in source space) ---
-            for frame_idx in all_frames:
-                fwd_box = forward.get(frame_idx,  {}).get(obj_id)
-                bwd_box = backward.get(frame_idx, {}).get(obj_id)
-
-                if fwd_box and bwd_box:
-                    box, _ = merge_boxes(fwd_box, bwd_box, iou_threshold)
-                elif fwd_box:
-                    box = fwd_box
-                elif bwd_box:
-                    box = bwd_box
-                else:
-                    continue
-
-                raw_boxes[int(frame_idx)] = box
+            if merged:
+                all_frames = sorted(set(merged.keys()),key=int)
+                for frame_idx in all_frames:
+                    raw_boxes[int(frame_idx)] = merged.get(frame_idx,  {}).get(obj_id)
+            else:
+                all_frames = sorted(set(forward.keys()),key=int)
+                for frame_idx in all_frames:
+                    raw_boxes[int(frame_idx)] = forward.get(frame_idx,  {}).get(obj_id)
 
             # --- compute target size ---
             target_size_w, target_size_h = get_target_size(raw_boxes, par, roundCrop, squareBox, exp_factor)


### PR DESCRIPTION
This pull request introduces improvements to how segmentation prompts are handled and optimizes the extraction of tracking data by supporting merged tracking directions. The main changes focus on enhancing metadata generation and simplifying the logic for extracting object tracking information.

**Metadata and prompt handling:**
- In `VideoMatting.py`, the segmentation prompt is now extracted from bounding box keys and stored in the `metadata_deep_model_base` under `Meshroom:mrSegmentation:Prompt`, ensuring that prompt information is consistently recorded.

**Tracking extraction logic:**
- In `bboxUtils.py`, the `extract_tracking` function now supports a `merged` direction in the tracking data. If present, it uses merged tracking data instead of separate forward/backward directions, simplifying the merging logic and making the code more robust for different tracking data formats.
- The logic for collecting object IDs and frames is streamlined: when `merged` data exists, only those keys are used; otherwise, the function falls back to the previous forward direction logic.