### PR TITLE
[sam3] Cryptomatte update in `VideoSegmentationSam3Text`

### DIFF
--- a/meshroom/sam3/VideoSegmentationSam3Text.py
+++ b/meshroom/sam3/VideoSegmentationSam3Text.py
@@ -515,7 +515,6 @@ cryptomatte from a text prompt.
         node.colorMasksBwd.value = color_mask_prefix + "_bwd_" + src_filename + ".png"
         node.colorMasksMerged.value = color_mask_prefix + "_merged_" + src_filename + ".exr"
         node.cryptomatte.value = cryptomatte_prefix + ("_merged_" if node.combineFwdAndBwdSeg.value else "_fwd_") + src_filename + ".exr"
-        #node.cryptomatteBwd.value = cryptomatte_prefix + "_bwd_" + src_filename + ".exr"
 
     def processChunk(self, chunk):
         from segmentationRDS import image, sam3Utils

--- a/meshroom/sam3/VideoSegmentationSam3Text.py
+++ b/meshroom/sam3/VideoSegmentationSam3Text.py
@@ -164,20 +164,12 @@ cryptomatte from a text prompt.
             enabled=lambda node: node.outputColorMasks.value and node.combineFwdAndBwdSeg.value,
         ),
         desc.File(
-            name="cryptomatteFwd",
-            label="Cryptomatte Forward",
-            description="Cryptomatte resulting from forward propagation embedded in EXR images.",
+            name="cryptomatte",
+            label="Cryptomatte",
+            description="Cryptomatte embedded in EXR images resulting from merged result if available, else from forward propagation only.",
             semantic="image",
             value=None,
             enabled=lambda node: node.outputCryptomatte.value,
-        ),
-        desc.File(
-            name="cryptomatteBwd",
-            label="Cryptomatte Backward",
-            description="Cryptomatte resulting from backward propagation embedded in EXR images.",
-            semantic="image",
-            value=None,
-            enabled=lambda node: node.outputCryptomatte.value and node.combineFwdAndBwdSeg.value,
         ),
     ]
 
@@ -298,8 +290,7 @@ cryptomatte from a text prompt.
             (not node.combineFwdAndBwdSeg.value and direction_name == "forward")
         )
 
-        write_cryptomatte = (direction_name in ["forward", "backward"])
-        crypto_name = "object" if text_prompt == "" else text_prompt
+        crypto_name = "cryptoObject" if text_prompt == "" else text_prompt.replace(" ", "_")
 
         for frame_id in frame_range:
             color_mask_image = np.zeros(source_info["shape"], dtype=source_info["dtype"])
@@ -307,7 +298,7 @@ cryptomatte from a text prompt.
             if (first_frame_id + frame_id) not in boxes[text_prompt][direction_name]:
                 boxes[text_prompt][direction_name][first_frame_id + frame_id] = {}
 
-            output_crypto = write_cryptomatte and node.outputCryptomatte.value
+            output_crypto = node.outputCryptomatte.value and is_definitive
             if output_crypto:
                 crypto_id = np.zeros((source_info["h_ori"], source_info["w_ori"]), dtype=np.float32)
                 crypto_cov = np.zeros((source_info["h_ori"], source_info["w_ori"]), dtype=np.float32)
@@ -330,7 +321,7 @@ cryptomatte from a text prompt.
 
                 # Generate IDs and hash structures for cryptomatte EXRs
                 if output_crypto:
-                    obj_name = f"{crypto_name}_{dir_prefix}_{int(key)}"
+                    obj_name = f"{crypto_name}_{int(key)}"
                     f32_hash, hex_val, _ = image.hash_name(obj_name)
                     manifest[obj_name] = hex_val
                     crypto_id[mask] = f32_hash
@@ -392,7 +383,8 @@ cryptomatte from a text prompt.
                     source_info["h_ori"],
                     manifest,
                     crypto_id,
-                    crypto_cov
+                    crypto_cov,
+                    color_mask_image
                 )
 
     def _update_tracking_at_step(
@@ -522,8 +514,8 @@ cryptomatte from a text prompt.
         node.colorMasksFwd.value = color_mask_prefix + "_fwd_" + src_filename + ".exr"
         node.colorMasksBwd.value = color_mask_prefix + "_bwd_" + src_filename + ".png"
         node.colorMasksMerged.value = color_mask_prefix + "_merged_" + src_filename + ".exr"
-        node.cryptomatteFwd.value = cryptomatte_prefix + "_fwd_" + src_filename + ".exr"
-        node.cryptomatteBwd.value = cryptomatte_prefix + "_bwd_" + src_filename + ".exr"
+        node.cryptomatte.value = cryptomatte_prefix + ("_merged_" if node.combineFwdAndBwdSeg.value else "_fwd_") + src_filename + ".exr"
+        #node.cryptomatteBwd.value = cryptomatte_prefix + "_bwd_" + src_filename + ".exr"
 
     def processChunk(self, chunk):
         from segmentationRDS import image, sam3Utils

--- a/meshroom/sam3/VideoSegmentationSam3Text.py
+++ b/meshroom/sam3/VideoSegmentationSam3Text.py
@@ -1,4 +1,4 @@
-__version__ = "2.0"
+__version__ = "2.1"
 
 import copy
 import logging

--- a/segmentationRDS/image.py
+++ b/segmentationRDS/image.py
@@ -243,28 +243,65 @@ def hash_name(name):
     f32_hex = hex(struct.unpack('<I', struct.pack('<f', f32_val))[0])[2:]
     return f32_val, f32_hex, hash_32
 
-def writeCryptomatte(filepath, crypto_name, w, h, manifest, crypto_id, crypto_cov):
+def writeCryptomatte(filepath, crypto_name, w, h, manifest, crypto_id, crypto_cov, preview = None):
     import OpenImageIO as oiio
     import json
     import numpy as np
 
-    spec = oiio.ImageSpec(w, h, 7, oiio.FLOAT)
-    spec.channelnames = (crypto_name+".red", crypto_name+".green", crypto_name+".blue",
-                        crypto_name+"00.red", crypto_name+"00.green", crypto_name+"00.blue", crypto_name+"00.alpha")
+    spec = oiio.ImageSpec(w, h, 8, oiio.FLOAT)
+    spec.channelnames = ("R", "G", "B", "A",
+                        f"{crypto_name}00.red", f"{crypto_name}00.green", f"{crypto_name}00.blue", f"{crypto_name}00.alpha")
     _, _, h32 = hash_name(crypto_name)
     crypto_key = f"{h32 & 0xFFFFFFFF:08x}"[:7]
     spec.attribute(f"cryptomatte/{crypto_key}/name", crypto_name)
-    spec.attribute(f"cryptomatte/{crypto_key}/manifest", json.dumps(manifest))
+    spec.attribute(f"cryptomatte/{crypto_key}/manifest", json.dumps(manifest, separators=(",", ":")))
     spec.attribute(f"cryptomatte/{crypto_key}/hash", "MurmurHash3_32")
     spec.attribute(f"cryptomatte/{crypto_key}/conversion", "uint32_to_float32")
+    spec.attribute(f"cryptomatte/{crypto_key}/version", "1.0")
 
-    crypto_zeros = np.zeros((h, w), dtype=np.float32)
-    cryptomatteImg = oiio.ImageOutput.create(str(filepath))
-    cryptomatteImg.open(filepath, spec)
-    cryptomatte_data = np.dstack((crypto_zeros, crypto_zeros, crypto_zeros, crypto_id, crypto_cov, crypto_zeros, crypto_zeros))
-    cryptomatteImg.write_image(cryptomatte_data)
-    cryptomatteImg.close()
+    zeros = np.zeros((h, w), dtype=np.float32)
 
+    preview = None if preview is None else np.asarray(preview)
+    if preview is not None:
+        if preview.ndim != 3:
+            raise ValueError(f"preview must be HxWxC, got shape {preview.shape}")
+        if preview.shape[0] != h or preview.shape[1] != w:
+            raise ValueError(f"preview size mismatch: expected ({h},{w},C), got {preview.shape}")
+        c = preview.shape[2]
+        if c == 3:
+            preview_rgb = preview.astype(np.float32)
+            alpha = np.ones((h, w, 1), dtype=np.float32)
+            preview_rgba = np.concatenate([preview_rgb, alpha], axis=2)
+        elif c == 4:
+            preview_rgba = preview.astype(np.float32)
+        else:
+            raise ValueError(f"Unsupported channel count in preview: {c} (expected 3 or 4)")
+    else:
+        preview_rgba = np.zeros((h, w, 4), dtype=np.float32)
+
+    crypto = np.dstack((
+        crypto_id.astype(np.float32),   # red   = id0
+        crypto_cov.astype(np.float32),  # green = cov0
+        zeros,                          # blue  = id1 (0)
+        zeros                           # alpha = cov1 (0)
+    ))
+
+    data = np.dstack((preview_rgba, crypto))  # (h,w,8)
+
+    out = oiio.ImageOutput.create(str(filepath))
+    if not out:
+        raise RuntimeError(f"Cannot create ImageOutput for {filepath}")
+    if not out.open(str(filepath), spec):
+        err = out.geterror()
+        out.close()
+        raise RuntimeError(f"Cannot open {filepath}: {err}")
+
+    ok = out.write_image(data)
+    err = out.geterror()
+    out.close()
+    if not ok:
+        raise RuntimeError(f"Write failed: {err}")
+   
 class paletteGenerator:
     def __init__(self, seed=42):
         self.seed = seed


### PR DESCRIPTION
This pull request refactors how Cryptomatte outputs are handled in the video segmentation pipeline, consolidating forward and backward outputs into a single merged Cryptomatte file, updating the EXR file structure, and improving the `writeCryptomatte` function for better compatibility and preview support. The main changes are grouped below:

**Cryptomatte Output Refactoring:**

* Removed separate `cryptomatteFwd` and `cryptomatteBwd` outputs and replaced them with a single `cryptomatte` output that stores the merged result if available, or the forward result otherwise. (`VideoSegmentationSam3Text.py`)
* Updated path resolution logic to generate only a single Cryptomatte output file, reflecting the new merged approach. (`VideoSegmentationSam3Text.py`)

**Cryptomatte Generation Logic:**

* Changed the logic so that Cryptomatte is only written for the definitive (merged or forward) segmentation result, not for every direction. Also, improved the naming convention for cryptomatte objects to avoid spaces. (`VideoSegmentationSam3Text.py`)

**EXR File Structure and Preview Support:**

* Updated the `writeCryptomatte` function to output 8-channel EXR files, with the first four channels containing an RGBA preview and the next four containing Cryptomatte data. Added validation for preview input and improved manifest formatting. (`image.py`)
* Ensured that the color mask preview is passed to `writeCryptomatte` when exporting, so the EXR file contains both the preview and the cryptomatte data. (`VideoSegmentationSam3Text.py`)

These changes simplify file outputs, improve interoperability with EXR viewers, and ensure that only the most relevant segmentation results are exported.