### PR TITLE
[segmentationRDS] Fix: Do not insert empty bounding boxes in merged tracking extraction

### DIFF
--- a/segmentationRDS/bboxUtils.py
+++ b/segmentationRDS/bboxUtils.py
@@ -234,11 +234,15 @@ def extract_tracking(
             if merged:
                 all_frames = sorted(set(merged.keys()),key=int)
                 for frame_idx in all_frames:
-                    raw_boxes[int(frame_idx)] = merged.get(frame_idx,  {}).get(obj_id)
+                    box = merged.get(frame_idx,  {}).get(obj_id)
+                    if box:
+                        raw_boxes[int(frame_idx)] = box
             else:
                 all_frames = sorted(set(forward.keys()),key=int)
                 for frame_idx in all_frames:
-                    raw_boxes[int(frame_idx)] = forward.get(frame_idx,  {}).get(obj_id)
+                    box = forward.get(frame_idx,  {}).get(obj_id)
+                    if box:
+                        raw_boxes[int(frame_idx)] = box
 
             # --- compute target size ---
             target_size_w, target_size_h = get_target_size(raw_boxes, par, roundCrop, squareBox, exp_factor)


### PR DESCRIPTION
This pull request makes a small but important fix to the `extract_tracking` function in `segmentationRDS/bboxUtils.py`. The change ensures that only non-empty bounding boxes are added to the `raw_boxes` dictionary, which helps prevent potential issues with empty or missing data.

* Only add bounding boxes to `raw_boxes` if they are present, avoiding the insertion of `None` values.