### PR TITLE
[vitMatte] Add a new parameter to limit the inference size

### DIFF
--- a/meshroom/vitMatte/ViTMatte.py
+++ b/meshroom/vitMatte/ViTMatte.py
@@ -399,10 +399,9 @@ Known Limitations:
                             matte = model(sample)
                             matte = matte['phas'].flatten(0, 2).squeeze(0)
                             matte = matte.detach().cpu().numpy()
-                            box_matteRGB = np.dstack([matte, matte, matte])
                             if limitedSize:
-                                matte = cv2.resize(matte, (w_inference, h_inference))
-                                box_matteRGB = cv2.resize(box_matteRGB, (w_inference, h_inference), interpolation=cv2.INTER_LINEAR)
+                                matte = cv2.resize(matte, (w_inference, h_inference), interpolation=cv2.INTER_LINEAR)
+                            box_matteRGB = np.dstack([matte, matte, matte])
                             tgt = matteRGB[y_top_inference:y_bottom_inference, x_left_inference:x_right_inference, :]
                             matteRGB[y_top_inference:y_bottom_inference, x_left_inference:x_right_inference, :] = np.maximum(tgt, box_matteRGB)
 

--- a/meshroom/vitMatte/ViTMatte.py
+++ b/meshroom/vitMatte/ViTMatte.py
@@ -104,6 +104,12 @@ Known Limitations:
             description="Use large model if enabled.",
             value=True,
         ),
+        desc.BoolParam(
+            name="limitInferenceSize",
+            label="Limit Inference Size",
+            description="If enabled, input image and trimap will be resized if needed.",
+            value=True,
+        ),
         desc.ChoiceParam(
             name="inferenceSize",
             label="Inference Size Max",
@@ -111,6 +117,7 @@ Known Limitations:
             value=1024,
             values=[512, 640, 768, 896, 1024, 2048],
             exclusive=True,
+            enabled=lambda node: node.limitInferenceSize.value,
         ),
         desc.BoolParam(
             name="useGpu",
@@ -280,6 +287,8 @@ Known Limitations:
             }
 
             sz = int(chunk.node.inferenceSize.value)
+            limitedSize = chunk.node.limitInferenceSize.value
+
 
             for k, (iFile, oFile) in enumerate(outFiles.items()):
                 if k >= chunk.range.start and k <= chunk.range.last:
@@ -366,27 +375,34 @@ Known Limitations:
                         img_for_inference = img[y_top_inference:y_bottom_inference, x_left_inference:x_right_inference, :]
                         trimap_for_inference = trimap_box[y_top_inference:y_bottom_inference, x_left_inference:x_right_inference]
 
-                        if w_inference > h_inference and w_inference > sz:
-                            inference_size = (sz, int(sz * h_inference / w_inference))
-                        elif h_inference > w_inference and h_inference > sz:
-                            inference_size = (int(sz * w_inference / h_inference), sz)
-                        elif w_inference == h_inference and w_inference > sz:
-                            inference_size = (sz, sz)
+                        if limitedSize:
+                            if w_inference > h_inference and w_inference > sz:
+                                inference_size = (sz, int(sz * h_inference / w_inference))
+                            elif h_inference > w_inference and h_inference > sz:
+                                inference_size = (int(sz * w_inference / h_inference), sz)
+                            elif w_inference == h_inference and w_inference > sz:
+                                inference_size = (sz, sz)
+                            else:
+                                inference_size = (w_inference, h_inference)
+                            logger.debug(f"inference size : {inference_size} ; ratio = {inference_size[0] / w_inference}")
+
+                            img_sized = cv2.resize(img_for_inference, inference_size, interpolation=cv2.INTER_LINEAR)
+                            box_trimap = np.expand_dims(cv2.resize(trimap_for_inference, inference_size, interpolation=cv2.INTER_NEAREST), axis=-1)
                         else:
-                            inference_size = (w_inference, h_inference)
+                            img_sized = img_for_inference
+                            box_trimap = np.expand_dims(trimap_for_inference, axis=-1)
 
-                        logger.debug(f"inference size : {inference_size} ; ratio = {inference_size[0] / w_inference}")
-
-                        img_sized = cv2.resize(img_for_inference, inference_size, interpolation=cv2.INTER_LINEAR)
-                        sample = {"image": F.to_tensor(img_sized).unsqueeze(0)}
-                        box_trimap = cv2.resize(trimap_for_inference, inference_size, interpolation=cv2.INTER_NEAREST)
-                        sample["trimap"] = F.to_tensor(box_trimap).unsqueeze(0)
+                        sample = {"image": torch.from_numpy(img_sized).permute(2, 0, 1).unsqueeze(0)}
+                        sample["trimap"] = torch.from_numpy(box_trimap).permute(2, 0, 1).unsqueeze(0)
 
                         with torch.no_grad():
-                            matte = model(sample)['phas'].flatten(0, 2)
-                            matte = cv2.resize(matte.detach().cpu().numpy(), (w_inference, h_inference))
+                            matte = model(sample)
+                            matte = matte['phas'].flatten(0, 2).squeeze(0)
+                            matte = matte.detach().cpu().numpy()
                             box_matteRGB = np.dstack([matte, matte, matte])
-                            box_matteRGB = cv2.resize(box_matteRGB, (w_inference, h_inference), interpolation=cv2.INTER_LINEAR)
+                            if limitedSize:
+                                matte = cv2.resize(matte, (w_inference, h_inference))
+                                box_matteRGB = cv2.resize(box_matteRGB, (w_inference, h_inference), interpolation=cv2.INTER_LINEAR)
                             tgt = matteRGB[y_top_inference:y_bottom_inference, x_left_inference:x_right_inference, :]
                             matteRGB[y_top_inference:y_bottom_inference, x_left_inference:x_right_inference, :] = np.maximum(tgt, box_matteRGB)
 


### PR DESCRIPTION
This pull request adds an option to limit the inference size in the `ViTMatte` node, improving flexibility and efficiency when processing images. The main changes introduce a new parameter to enable or disable automatic resizing of input images and trimaps, and adjust the inference pipeline to respect this setting.

**Parameter and UI changes:**

* Added a new boolean parameter `limitInferenceSize` to the `ViTMatte` node, allowing users to enable or disable automatic resizing of input images and trimaps for inference. The `inferenceSize` parameter is now only enabled if `limitInferenceSize` is `True`.

**Inference pipeline logic:**

* Updated the `processChunk` method to check the `limitInferenceSize` parameter and conditionally resize the input image and trimap only when this option is enabled.
* Modified the data preparation for inference: when resizing is disabled, the original image and trimap are used without resizing; when enabled, both are resized to the specified inference size.
* Adjusted the post-processing step to resize the output matte only if resizing was applied during inference, ensuring correct output dimensions.